### PR TITLE
175 implement ytt integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ Ansible forms is a lightweight node.js webapplication to generate userfriendly a
 
 # Configuration / documentation
 [Go to the documentation website](https://ansibleforms.com)
+
+# Custom Configuration Options
+
+| ENV VAR         | Description                                     |
+|-----------------|-------------------------------------------------|
+| SHOW_DESIGNER   | Show the designer in the menu bar               |
+| USE_YTT         | Use https://carvel.dev/ytt/ for yaml templating |
+| YTT_VARS_PREFIX | ENV var prefix for ytt data variables           |

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Ansible forms is a lightweight node.js webapplication to generate userfriendly a
 
 # Custom Configuration Options
 
-| ENV VAR         | Description                                     |
-|-----------------|-------------------------------------------------|
-| SHOW_DESIGNER   | Show the designer in the menu bar               |
-| USE_YTT         | Use https://carvel.dev/ytt/ for yaml templating |
-| YTT_VARS_PREFIX | ENV var prefix for ytt data variables           |
+| ENV VAR         | Description                                                                                                                                                   |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SHOW_DESIGNER   | Show the designer in the menu bar                                                                                                                             |
+| USE_YTT         | Use https://carvel.dev/ytt/ for yaml templating                                                                                                               |
+| YTT_VARS_PREFIX | ENV var prefix for ytt data variables                                                                                                                         |
+| YTT_LIB_DATA_*  | Data value files for ytt libraries. * is the name of the library. e.g. YTT_LIB_DATA_PAYLOADS=/tmp/payloads.yml. The data will be provided to forms.yaml only! |

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -116,6 +116,18 @@
       Although we encourage you to use an editor such as **Visual Studio Code** to edit the forms.yaml file, preferably with some form of source control.  Ansible Forms comes with an internal yaml designer.  
       And although only admins can see the designer, you might want to disable it completely by setting this variable to 0.
     version: 4.0.0
+  - name: USE_YTT
+    type: number
+    choices:
+      - name: 0
+        description: Does not execute ytt on the forms.yaml
+      - name: 1
+        description: Executes ytt on the forms.yaml
+    default: 0
+    short: Enable the ytt interpreter
+    description: |
+      https://github.com/carvel-dev/ytt is a tool for yaml templating. It can be activated by this variable.
+    version: 5.0.1
   - name: LOG_LEVEL
     type: string
     choices:

--- a/server/config/app.config.js
+++ b/server/config/app.config.js
@@ -5,6 +5,7 @@ var app_config = {
   baseUrl: process.env.BASE_URL || "/",
   nodeEnvironment: process.env.NODE_ENV || "production",
   showDesigner: process.env.SHOW_DESIGNER ?? true,
+  useYtt: process.env.USE_YTT ?? false,
   formsPath: process.env.FORMS_PATH || path.resolve(__dirname + "/../persistent/forms.yaml"),
   lockPath: process.env.LOCK_PATH || path.resolve(__dirname + "/../persistent/ansibleForms.lock"),
   helpPath: path.resolve(__dirname + "/../help.yaml"),

--- a/server/src/models/form.model.js
+++ b/server/src/models/form.model.js
@@ -13,8 +13,6 @@ const path=require("path")
 const AJVErrorParser = require('ajv-error-parser');
 const Repository = require('./repository.model')
 const Helpers = require("../lib/common")
-const {inspect} = require("node:util");
-const Repo = require('./repo.model');
 
 const backupPath = appConfig.formsBackupPath
 
@@ -76,13 +74,17 @@ Form.load = async function() {
   var formfilesraw=[]
   var formfiles=[]
   var files=undefined
+  var ytt_data_opt = ''
+  if ('YTT_VARS_PREFIX' in process.env) {
+    ytt_data_opt = `--data-values-env ${process.env.YTT_VARS_PREFIX}`
+  }
   try{
     // read base forms.yaml
     rawdata = '';
     try {
       if (appConfig.useYtt) {
         logger.info(`interpreting ${appFormsPath} with ytt.`);
-        rawdata = execSync(`ytt -f ${appFormsPath} -f ${formslibdirpath}`, {encoding: 'utf-8'});
+        rawdata = execSync(`ytt -f ${appFormsPath} -f ${formslibdirpath} ${ytt_data_opt}`, {encoding: 'utf-8'});
       } else {
         rawdata = fs.readFileSync(appFormsPath, 'utf8');
       }
@@ -104,7 +106,7 @@ Form.load = async function() {
             var itemRawData = '';
             if (appConfig.useYtt) {
               logger.info(`interpreting ${itemFormPath} with ytt.`);
-              itemRawData = execSync(`ytt -f ${itemFormPath} -f ${formslibdirpath}`,{ encoding: 'utf-8' });
+              itemRawData = execSync(`ytt -f ${itemFormPath} -f ${formslibdirpath} ${ytt_data_opt}`,{ encoding: 'utf-8' });
             } else {
               itemRawData =fs.readFileSync(itemFormPath,'utf8');
             }

--- a/server/src/models/form.model.js
+++ b/server/src/models/form.model.js
@@ -100,7 +100,13 @@ Form.load = async function() {
       if (appConfig.useYtt) {
         logger.info(`interpreting ${appFormsPath} with ytt.`);
         logger.debug(`executing 'ytt -f ${appFormsPath} -f ${formslibdirpath}${ytt_env_data_opt}${yttLibDataOpts}'`)
-        rawdata = execSync(`ytt -f ${appFormsPath} -f ${formslibdirpath}${ytt_env_data_opt}${yttLibDataOpts}`, {encoding: 'utf-8'});
+        rawdata = execSync(
+            `ytt -f ${appFormsPath} -f ${formslibdirpath}${ytt_env_data_opt}${yttLibDataOpts}`,
+            {
+              env: process.env,
+              encoding: 'utf-8'
+            }
+        );
       } else {
         rawdata = fs.readFileSync(appFormsPath, 'utf8');
       }
@@ -123,7 +129,13 @@ Form.load = async function() {
             if (appConfig.useYtt) {
               logger.info(`interpreting ${itemFormPath} with ytt.`);
               logger.debug(`executing 'ytt -f ${itemFormPath} -f ${formslibdirpath}${ytt_env_data_opt}'`)
-              itemRawData = execSync(`ytt -f ${itemFormPath} -f ${formslibdirpath}${ytt_env_data_opt}`,{ encoding: 'utf-8' });
+              itemRawData = execSync(
+                  `ytt -f ${itemFormPath} -f ${formslibdirpath}${ytt_env_data_opt}`,
+                  {
+                    env: process.env,
+                    encoding: 'utf-8'
+                  }
+              );
             } else {
               itemRawData =fs.readFileSync(itemFormPath,'utf8');
             }


### PR DESCRIPTION
implement #175 

This pull request implements ytt integration.
It can be enabled by setting `USE_YTT=1`.
A `lib` directory needs to exist within the root directory and is automatically included for the ytt call.
Data can be provided globally by setting prefixed environment variables:  
```bash
YTT_VARS_PREFIX=YTT_VAR
YTT_VAR_INVENTORY_PATH=/tmp/inventory.yml
YTT_VAR_default_host=localhost
```  
Or by providing library data files:
```bash
YTT_LIB_DATA_DEMO=/tmp/demo_data.yml
```  
```yaml
# /tmp/demo_data.yml
message: 'hello demo'
```
**The library `demo` needs to exists in the ytt context (lib/_ytt_lib/demo/values.yml)**
```yaml
# lib/_ytt_lib/demo/values.yml
#@ data/values
---
demo: {}
```  
  
Then, the loaded data can be used:
```yaml
# forms.yaml
#@ load("@ytt:data", "data")
#@ load("@ytt:library", "library")
#@ demo = library.get("demo")
---
categories:
  - name: Default
    icon: bars
roles:
  - name: admin
    groups:
      - local/admins
constants:
  data_values: #@ data.values
  demo: #@ demo.data_values()
forms:
  - name: Demo Form
    type: ansible
    inventory: #@ data.values.INVENTORY_PATH
    playbook: dummy.yml
fields:
  - name: var_message
    type: text
    label: Message
    default: Object($(demo)).message
    eval_default: true
```
