### PR TITLE
Skip schema check

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ Ansible forms is a lightweight node.js webapplication to generate userfriendly a
 
 # Configuration / documentation
 [Go to the documentation website](https://ansibleforms.com)
+
+# Custom Configuration Options
+
+| ENV VAR           | Description                                                                                                                                                   |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SHOW_DESIGNER     | Show the designer in the menu bar                                                                                                                             |
+| USE_YTT           | Use https://carvel.dev/ytt/ for yaml templating                                                                                                               |
+| YTT_VARS_PREFIX   | ENV var prefix for ytt data variables                                                                                                                         |
+| YTT_LIB_DATA_*    | Data value files for ytt libraries. * is the name of the library. e.g. YTT_LIB_DATA_PAYLOADS=/tmp/payloads.yml. The data will be provided to forms.yaml only! |
+| SKIP_SCHEMA_CHECK | Skip the schema check                                                                                                                                         |

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -128,6 +128,18 @@
     description: |
       https://github.com/carvel-dev/ytt is a tool for yaml templating. It can be activated by this variable.
     version: 5.0.2
+  - name: SKIP_SCHEMA_CHECK
+    type: number
+    choices:
+      - name: 0
+        description: Does check the schema when querying '/'
+      - name: 1
+        description: Does not check the schema when querying '/'
+    default: 0
+    short: Skip the schema check
+    description: |
+      Schema check is performed whenever fetching '/'. This can be skipped.
+    version: 5.0.2
   - name: LOG_LEVEL
     type: string
     choices:

--- a/server/config/app.config.js
+++ b/server/config/app.config.js
@@ -7,6 +7,7 @@ var app_config = {
   showDesigner: (process.env.SHOW_DESIGNER ?? 1)==1,
   formsPath: process.env.FORMS_PATH || path.resolve(__dirname + "/../persistent/forms.yaml"),
   useYtt: (process.env.USE_YTT ?? 0)==1,
+  skipSchemaCheck: (process.env.SKIP_SCHEMA_CHECK ?? 0) == 1,
   lockPath: process.env.LOCK_PATH || path.resolve(__dirname + "/../persistent/ansibleForms.lock"),
   helpPath: path.resolve(__dirname + "/../help.yaml"),
   encryptionSecret: ((process.env.ENCRYPTION_SECRET + "vOVH6sdmpNWjRRIqCc7rdxs01lwHzfr3").substring(0,32)) || "vOVH6sdmpNWjRRIqCc7rdxs01lwHzfr3",

--- a/server/src/controllers/schema.controller.js
+++ b/server/src/controllers/schema.controller.js
@@ -4,7 +4,7 @@ var RestResult = require('../models/restResult.model');// our personal app setti
 const appConfig = require('../../config/app.config')
 
 exports.hasSchema = function(req, res) {
-    if (appConfig.skipSchemaCheck) {
+    if (!req.originalUrl.includes("schema") && appConfig.skipSchemaCheck) {
         return res.json(new RestResult("success", "Schema check skipped due to configuration.", [], []))
     }
 

--- a/server/src/controllers/schema.controller.js
+++ b/server/src/controllers/schema.controller.js
@@ -1,8 +1,13 @@
 'use strict';
 const Schema = require('../models/schema.model');
-var RestResult = require('../models/restResult.model');
+var RestResult = require('../models/restResult.model');// our personal app settings
+const appConfig = require('../../config/app.config')
 
 exports.hasSchema = function(req, res) {
+    if (appConfig.skipSchemaCheck) {
+        return res.json(new RestResult("success", "Schema check skipped due to configuration.", [], []))
+    }
+
     Schema.hasSchema()
       .then((result)=>{ res.json(new RestResult("success","schema and tables are ok",result.data?.success,result.data?.failed)) })
       .catch((result)=>{ 


### PR DESCRIPTION
The schema check is done on each request.  
This includes calling the `patch_all` method. Some indices are recreated and column types are modified.  
  
This should only be done if necessary.  
  
This PR introduces the most simple fix by just skipping the check for all requests except the schema endpoints.