### PR TITLE
Issue 244 add issuer to jwt

### DIFF
--- a/server/src/controllers/login.controller.js
+++ b/server/src/controllers/login.controller.js
@@ -17,8 +17,8 @@ function userToJwt(user,expiryDays){
   // {"username":"administrator","type":"local","roles":["public","admin"]}
 
   // we create 2 jwt tokens (accesstoken and refresh token)
-  const token = jwt.sign({user,access:true}, authConfig.secret,{ expiresIn: expiryDays || authConfig.jwtExpiration, issuer: process.env.BASE_URL});
-  const refreshtoken = jwt.sign({user,refresh:true}, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration, issuer: process.env.BASE_URL});
+  const token = jwt.sign({user,access:true}, authConfig.secret,{ expiresIn: expiryDays || authConfig.jwtExpiration, issuer: process.env.JWT_ISSUER || "ansibleforms"});
+  const refreshtoken = jwt.sign({user,refresh:true}, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration, issuer: process.env.JWT_ISSUER || "ansibleforms"});
   logger.debug(JSON.stringify(user))
   // we store the tokens in the database, to later verify a refresh token action
   logger.info("Storing refreshtoken in database for user " + user.username)

--- a/server/src/controllers/login.controller.js
+++ b/server/src/controllers/login.controller.js
@@ -17,8 +17,8 @@ function userToJwt(user,expiryDays){
   // {"username":"administrator","type":"local","roles":["public","admin"]}
 
   // we create 2 jwt tokens (accesstoken and refresh token)
-  const token = jwt.sign({user,access:true}, authConfig.secret,{ expiresIn: expiryDays || authConfig.jwtExpiration});
-  const refreshtoken = jwt.sign({user,refresh:true}, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration});
+  const token = jwt.sign({user,access:true}, authConfig.secret,{ expiresIn: expiryDays || authConfig.jwtExpiration, issuer: process.env.BASE_URL});
+  const refreshtoken = jwt.sign({user,refresh:true}, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration, issuer: process.env.BASE_URL});
   logger.debug(JSON.stringify(user))
   // we store the tokens in the database, to later verify a refresh token action
   logger.info("Storing refreshtoken in database for user " + user.username)

--- a/server/src/controllers/token.controller.js
+++ b/server/src/controllers/token.controller.js
@@ -24,8 +24,8 @@ exports.refresh = function(req, res) {
               var body = jwtPayload.user
               if(new Date(jwtPayload.exp*1000)>new Date()){
                 // logger.info("refresh token is not expired")
-                const token = jwt.sign({ user: body,access:true }, authConfig.secret,{ expiresIn: authConfig.jwtExpiration, issuer: process.env.BASE_URL});
-                const refreshtoken = jwt.sign({ user: body,refresh:true }, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration, issuer: process.env.BASE_URL});
+                const token = jwt.sign({ user: body,access:true }, authConfig.secret,{ expiresIn: authConfig.jwtExpiration, issuer: process.env.JWT_ISSUER || "ansibleforms"});
+                const refreshtoken = jwt.sign({ user: body,refresh:true }, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration, issuer: process.env.JWT_ISSUER || "ansibleforms"});
                 User.storeToken(username,username_type,refreshtoken)
                   .then(()=>{
                     logger.info("Token is renewed and stored")

--- a/server/src/controllers/token.controller.js
+++ b/server/src/controllers/token.controller.js
@@ -24,8 +24,8 @@ exports.refresh = function(req, res) {
               var body = jwtPayload.user
               if(new Date(jwtPayload.exp*1000)>new Date()){
                 // logger.info("refresh token is not expired")
-                const token = jwt.sign({ user: body,access:true }, authConfig.secret,{ expiresIn: authConfig.jwtExpiration});
-                const refreshtoken = jwt.sign({ user: body,refresh:true }, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration});
+                const token = jwt.sign({ user: body,access:true }, authConfig.secret,{ expiresIn: authConfig.jwtExpiration, issuer: process.env.BASE_URL});
+                const refreshtoken = jwt.sign({ user: body,refresh:true }, authConfig.secret,{ expiresIn: authConfig.jwtRefreshExpiration, issuer: process.env.BASE_URL});
                 User.storeToken(username,username_type,refreshtoken)
                   .then(()=>{
                     logger.info("Token is renewed and stored")


### PR DESCRIPTION
This pull request adds the option to mention a JWT_ISSUER in order to be compatible with  solutions that implement filtering or validation of the JWTs.

When JWT_ISSUER is not defined it uses the generic "ansibleforms" issuer.

Tested on a production deployment on Kubernetes, this fixes issue #244 successfully !