### PR TITLE
Add YTT symlink options and shell quote ytt command arguments

### DIFF
--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -4347,7 +4347,7 @@
       # /tmp/demo_data.yml
       message: 'hello demo'
       ```
-      **The library `demo` needs to exists in the ytt context (lib/_ytt_lib/demo/values.yml)**
+      **The library `demo` needs to exist in the ytt context (lib/_ytt_lib/demo/values.yml)**
       ```yaml
       # lib/_ytt_lib/demo/values.yml
       #@ data/values
@@ -4383,4 +4383,14 @@
           label: Message
           default: Object($(demo)).message
           evalDefault: true
-      ```      
+      ```
+
+      By default, templating with symlinks is disabled in ytt, but it is possible to enable them using one of the following environment variables:
+      ```bash
+      YTT_ALLOW_SYMLINK_DESTINATIONS=/paths/to/allow
+      # or
+      YTT_DANGEROUS_ALLOW_ALL_SYMLINK_DESTINATIONS=true
+      ```
+      These are mapped to their corresponding command line options.
+      **NOTE** : enabling this may come with certain risks.
+      More info: https://carvel.dev/ytt/docs/latest/faq/#how-can-i-use-files-that-are-symlinks


### PR DESCRIPTION
Adds two environment variables to allow YTT templating using symlinks, mapped to the ytt CLI options:
```bash
YTT_ALLOW_SYMLINK_DESTINATIONS=/paths/to/allow # Mapped to --allow-symlink-destination
YTT_DANGEROUS_ALLOW_ALL_SYMLINK_DESTINATIONS=true # Mapped to --dangerous-allow-all-symlink-destinations
```
Following this: https://carvel.dev/ytt/docs/latest/faq/#how-can-i-use-files-that-are-symlinks

And adds shell quoting to ytt CLI args in the process.