### PR TITLE
Ansibleguy76/ansibleforms#318

### DIFF
--- a/client_new/src/components/AppForm.vue
+++ b/client_new/src/components/AppForm.vue
@@ -1484,7 +1484,7 @@
                                         <BsInputForForm v-else @dblclick="setExpressionFieldViewable(field.name, true)" type="expression" :icon="field.icon" :hasError="v$.form[field.name].$invalid" cssClass="text-info" v-model="v$.form[field.name].$model" :name="field.name" :isHtml="field.isHtml"  :errors="v$.form[field.name].$errors" />
                                     </div>
                                     <!-- expression raw data -->
-                                    <div @dblclick="setExpressionFieldViewable(field.name, false)" v-else class="card p-2 limit-height is-limited">
+                                    <div @dblclick="setExpressionFieldViewable(field.name, false)" v-else class="card p-2 limit-height">
                                         <!-- <pre v-highlightjs><code lang="json">{{ v$.form[field.name].$model }}</code></pre> -->
                                          <VueJsonPretty :data="v$.form[field.name].$model" />
                                     </div>
@@ -1515,8 +1515,8 @@
     </div>
 </template>
 <style scoped lang="scss">
-
 .limit-height {
+
     max-height: 300px;
     overflow-y: scroll;
     overflow-x: clip;

--- a/client_new/src/components/AppForm.vue
+++ b/client_new/src/components/AppForm.vue
@@ -1515,8 +1515,8 @@
     </div>
 </template>
 <style scoped lang="scss">
-.limit-height {
 
+.limit-height {
     max-height: 300px;
     overflow-y: scroll;
     overflow-x: clip;


### PR DESCRIPTION
Unless I'm missing something, when applying both the .is-limited and the .limit-height rule to an element, the directive overflow: hidden (which is a shorthand for setting overflow-y and overflow-x to hidden) in the .is-limited rule overrules the corresponding directives in the .limit-height rule, because it's defined later. Therefore the textboxes couldn't be scrolled. 

Closes #318 