### PR TITLE
Replace manual JWT decoding helper with jwt-decode library

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
     "copy-to-clipboard": "^3.3.3",
     "core-js": "^3.48.0",
     "jsonwebtoken": "^9.0.3",
+    "jwt-decode": "^4.0.0",
     "roboto-fontface": "*",
     "dayjs": "^1.11.19",
     "vue": "^3.5.28",

--- a/client/src/pages/login.vue
+++ b/client/src/pages/login.vue
@@ -9,35 +9,12 @@ import { toast } from 'vue-sonner';
 import { useRoute, useRouter } from "vue-router";
 import axios from "axios";
 import Theme from "@/lib/Theme";
+import { jwtDecode } from "jwt-decode";
 
 // plugins
 
 const route = useRoute();
 const router = useRouter();
-
-// Decode JWT payload without jwt.decode, install library, e.g. jwt-decode, instead?
-function decodeJwtPayload(token) {
-  if (!token) return null;
-
-  const parts = token.split(".");
-  if (parts.length < 2) return null;
-
-  // Base64url -> Base64
-  const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-
-  try {
-    const json = decodeURIComponent(
-      atob(base64)
-        .split("")
-        .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
-        .join("")
-    );
-    return JSON.parse(json);
-  } catch (e) {
-    console.error("Failed to decode JWT payload", e);
-    return null;
-  }
-}
 
 // vuelidate
 const rules = {
@@ -105,8 +82,8 @@ function getGroupsAndLogin(token, url = `${azureGraphUrl.value}/v1.0/me/transiti
    }
    else {
     // OIDC branch for now => specify type in the future?
-    // decode JWT with helper instead of using undefined `jwt.decode`
-    const payload = decodeJwtPayload(token);
+    // decode token with "jwt-decode"
+    const payload = jwtDecode(token);
 
     if (!payload) {
       toast.error("Failed to decode login token");


### PR DESCRIPTION
Hi ansibleguy76,

sorry for only replying you now after almost three months. I finally came around to trying out the latest develop branch with our Keycloak instance and I can confirm that it worked.
While I had the setup, I also replaced the custom token decode through an external library: https://www.npmjs.com/package/jwt-decode

Best regards,
Jan