### PR TITLE
fix: LDAP TLS - declare certs variable and use correct ca_bundle property

### DIFF
--- a/server/src/lib/common.js
+++ b/server/src/lib/common.js
@@ -50,7 +50,7 @@ Helpers.escapeStringForCommandLine=function(value) {
 }
 
 Helpers.checkCertificate=function(cert){
-  certs=cert.replace(/-----(\r\n|\n|\r)-----/gm,"-----|-----").split("|")
+  var certs=cert.replace(/-----(\r\n|\n|\r)-----/gm,"-----|-----").split("|")
   if(certs.length>1){
     logger.debug("Certificate is a bundle...")
   }else{

--- a/server/src/models/ldap.model.js
+++ b/server/src/models/ldap.model.js
@@ -103,7 +103,7 @@ Ldap.check = async function(ldapConfig){
         options.ldapOpts.tlsOptions.cert = ldapConfig.cert
       }
       if(ldapConfig.ca_bundle!=""){
-        options.ldapOpts.tlsOptions.ca = ldapConfig.ldapTlsCa
+        options.ldapOpts.tlsOptions.ca = ldapConfig.ca_bundle
       }
       options.ldapOpts.tlsOptions.rejectUnauthorized = !(ldapConfig.ignore_certs==1)
       logger.info("use tls : " + (ldapConfig.enable_tls==1))


### PR DESCRIPTION
Closes #432

## Summary

Two bugs in the LDAP TLS code path that together break LDAP connections when `enable_tls=1` and `ignore_certs=0`:

- **`server/src/lib/common.js`** — `certs` variable in `checkCertificate()` was used without declaration, causing `ReferenceError` in strict/ESM mode
- **`server/src/models/ldap.model.js`** — CA bundle was read from `ldapConfig.ldapTlsCa` (which doesn't exist) instead of `ldapConfig.ca_bundle`, so the CA certificate was never passed to the TLS stack

## Changes

```diff
- certs=cert.replace(/-----(\r\n|\n|\r)-----/gm,"-----|-----").split("|")
+ var certs=cert.replace(/-----(\r\n|\n|\r)-----/gm,"-----|-----").split("|")

- options.ldapOpts.tlsOptions.ca = ldapConfig.ldapTlsCa
+ options.ldapOpts.tlsOptions.ca = ldapConfig.ca_bundle

**Test plan**
Configure LDAP with enable_tls=1, ignore_certs=0, and a valid CA bundle
Click "Test LDAP connection"
Verify connection succeeds without ReferenceError

**Version**
Found in v6.1.2, confirmed still present in current main.