### PR TITLE
Add output and graph visualization for AWX workflow jobs (fixes #420)

### DIFF
--- a/client/src/components/AppAwxWorkflow.vue
+++ b/client/src/components/AppAwxWorkflow.vue
@@ -1,0 +1,245 @@
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+    /******************************************************************/
+    /*                                                                */
+    /*  Awx Workflow component                                        */
+    /*  Visualize an awx workflow job as a graph, similar to the      */
+    /*  awx workflow output view.  Nodes are painted by status        */
+    /*  (green=successful, red=failed, ...) and the links are         */
+    /*  painted by relation (success, failure, always)                */
+    /*                                                                */
+    /*  @props:                                                       */
+    /*      workflow: Object                                          */
+    /*        { id, name, status, nodes: [                            */
+    /*            { id, name, type, status, elapsed,                  */
+    /*              success_nodes, failure_nodes, always_nodes } ] }  */
+    /*                                                                */
+    /******************************************************************/
+
+    const props = defineProps({
+        workflow: {
+            type: Object,
+            required: true
+        }
+    });
+
+    const { t } = useI18n();
+
+    // layout constants
+    const NODE_W = 170;
+    const NODE_H = 52;
+    const GAP_X = 60;
+    const GAP_Y = 24;
+    const MARGIN = 15;
+    const START_W = 70;
+    const START_H = 32;
+
+    // node colors by awx job status
+    const statusColors = {
+        successful: 'var(--bs-success)',
+        failed: 'var(--bs-danger)',
+        error: 'var(--bs-danger)',
+        unreachable: 'var(--bs-danger)',
+        running: 'var(--bs-primary)',
+        canceled: 'var(--bs-warning)',
+    };
+    // link colors by relation type
+    const edgeColors = {
+        success: 'var(--bs-success)',
+        failure: 'var(--bs-danger)',
+        always: 'var(--bs-info)',
+        start: 'var(--bs-secondary)',
+    };
+
+    function statusColor(status) {
+        return statusColors[status] || 'var(--bs-secondary)';
+    }
+
+    // badge class for the workflow status
+    const statusBadges = {
+        successful: 'text-bg-success',
+        failed: 'text-bg-danger',
+        error: 'text-bg-danger',
+        running: 'text-bg-info',
+        canceled: 'text-bg-warning',
+    };
+    function statusBadge(status) {
+        return statusBadges[status] || 'text-bg-secondary';
+    }
+
+    // a smooth bezier link between 2 points
+    function linkPath(x1, y1, x2, y2) {
+        const dx = Math.max(30, (x2 - x1) / 2);
+        return `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
+    }
+
+    function truncate(s, len = 20) {
+        return (s && s.length > len) ? s.slice(0, len - 1) + '…' : s;
+    }
+
+    // compute the graph layout (layered DAG, like the awx workflow visualizer)
+    const graph = computed(() => {
+        const nodes = props.workflow?.nodes || [];
+        const byId = {};
+        nodes.forEach(n => { byId[n.id] = n });
+        // collect the links
+        const edges = [];
+        nodes.forEach(n => {
+            (n.success_nodes || []).forEach(c => byId[c] && edges.push({ from: n.id, to: c, type: 'success' }));
+            (n.failure_nodes || []).forEach(c => byId[c] && edges.push({ from: n.id, to: c, type: 'failure' }));
+            (n.always_nodes || []).forEach(c => byId[c] && edges.push({ from: n.id, to: c, type: 'always' }));
+        });
+        // roots are nodes without incoming links
+        const hasParent = new Set(edges.map(e => e.to));
+        const roots = nodes.filter(n => !hasParent.has(n.id));
+        // depth = longest path from a root (relaxation, awx guarantees a DAG)
+        const depth = {};
+        nodes.forEach(n => { depth[n.id] = 0 });
+        for (let i = 0; i < nodes.length; i++) {
+            let changed = false;
+            edges.forEach(e => {
+                if (depth[e.from] + 1 > depth[e.to]) {
+                    depth[e.to] = depth[e.from] + 1;
+                    changed = true;
+                }
+            });
+            if (!changed) break;
+        }
+        // group the nodes in columns by depth
+        const columns = {};
+        nodes.forEach(n => {
+            (columns[depth[n.id]] = columns[depth[n.id]] || []).push(n);
+        });
+        const maxDepth = Math.max(0, ...Object.keys(columns).map(Number));
+        const maxRows = Math.max(1, ...Object.values(columns).map(c => c.length));
+        const height = MARGIN * 2 + maxRows * NODE_H + (maxRows - 1) * GAP_Y;
+        const width = MARGIN * 2 + START_W + GAP_X + (maxDepth + 1) * NODE_W + maxDepth * GAP_X;
+        // position the nodes, each column vertically centered
+        const pos = {};
+        Object.entries(columns).forEach(([d, list]) => {
+            list.sort((a, b) => a.id - b.id);
+            const colH = list.length * NODE_H + (list.length - 1) * GAP_Y;
+            const y0 = (height - colH) / 2;
+            list.forEach((n, i) => {
+                pos[n.id] = {
+                    x: MARGIN + START_W + GAP_X + Number(d) * (NODE_W + GAP_X),
+                    y: y0 + i * (NODE_H + GAP_Y)
+                };
+            });
+        });
+        const start = { x: MARGIN, y: height / 2 - START_H / 2 };
+        // build the link paths
+        const links = edges.map(e => ({
+            type: e.type,
+            d: linkPath(pos[e.from].x + NODE_W, pos[e.from].y + NODE_H / 2, pos[e.to].x, pos[e.to].y + NODE_H / 2)
+        }));
+        roots.forEach(r => {
+            links.push({
+                type: 'start',
+                d: linkPath(start.x + START_W, start.y + START_H / 2, pos[r.id].x, pos[r.id].y + NODE_H / 2)
+            });
+        });
+        return {
+            nodes: nodes.map(n => ({ ...n, ...pos[n.id] })),
+            links,
+            width,
+            height,
+            start
+        };
+    });
+
+</script>
+<template>
+    <div class="awx-workflow card p-3 mb-3">
+        <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
+            <h5 class="mb-0">{{ workflow.name }}
+                <sup><span class="badge rounded-pill" :class="statusBadge(workflow.status)">{{ workflow.status }}</span></sup>
+            </h5>
+            <div class="awx-workflow-legend small text-body-secondary">
+                <span class="me-3"><span class="legend-line" :style="{ background: edgeColors.success }"></span>{{ t('workflow.onSuccess') }}</span>
+                <span class="me-3"><span class="legend-line" :style="{ background: edgeColors.failure }"></span>{{ t('workflow.onFailure') }}</span>
+                <span><span class="legend-line" :style="{ background: edgeColors.always }"></span>{{ t('workflow.always') }}</span>
+            </div>
+        </div>
+        <div class="awx-workflow-scroll">
+            <svg :width="graph.width" :height="graph.height" :viewBox="`0 0 ${graph.width} ${graph.height}`">
+                <!-- links -->
+                <path v-for="(l, i) in graph.links" :key="'link' + i" :d="l.d" fill="none" :stroke="edgeColors[l.type]" stroke-width="2" opacity="0.8" />
+                <!-- start node -->
+                <g>
+                    <rect :x="graph.start.x" :y="graph.start.y" :width="START_W" :height="START_H" :rx="START_H / 2" class="awx-start" />
+                    <text :x="graph.start.x + START_W / 2" :y="graph.start.y + START_H / 2 + 4" text-anchor="middle" class="awx-start-text">START</text>
+                </g>
+                <!-- workflow nodes -->
+                <g v-for="n in graph.nodes" :key="n.id" class="awx-node">
+                    <rect :x="n.x" :y="n.y" :width="NODE_W" :height="NODE_H" rx="6" class="awx-node-rect"
+                        :style="{ stroke: statusColor(n.status) }"
+                        :stroke-dasharray="(n.status == 'skipped' || n.do_not_run) ? '4 3' : null" />
+                    <circle :cx="n.x + 14" :cy="n.y + NODE_H / 2" r="5" :fill="statusColor(n.status)"
+                        :class="{ 'awx-pulse': n.status == 'running' }" />
+                    <text :x="n.x + 26" :y="n.y + 22" class="awx-node-name">{{ truncate(n.name) }}</text>
+                    <text :x="n.x + 26" :y="n.y + 40" class="awx-node-status" :style="{ fill: statusColor(n.status) }">
+                        {{ n.status }}<template v-if="n.elapsed > 0"> · {{ Math.round(n.elapsed) }}s</template>
+                    </text>
+                    <title>{{ n.name }} ({{ n.status }})</title>
+                </g>
+            </svg>
+        </div>
+    </div>
+</template>
+<style lang="scss" scoped>
+    .awx-workflow {
+        background-color: var(--af-bg-light-subtle-color, var(--bs-body-bg));
+
+        .awx-workflow-scroll {
+            overflow-x: auto;
+        }
+
+        .legend-line {
+            display: inline-block;
+            width: 18px;
+            height: 3px;
+            border-radius: 2px;
+            vertical-align: middle;
+            margin-right: 5px;
+        }
+
+        .awx-start {
+            fill: var(--bs-secondary);
+        }
+
+        .awx-start-text {
+            fill: var(--bs-light);
+            font-size: .7rem;
+            font-weight: bold;
+            letter-spacing: 1px;
+        }
+
+        .awx-node-rect {
+            fill: var(--bs-body-bg);
+            stroke-width: 2;
+        }
+
+        .awx-node-name {
+            fill: var(--bs-body-color);
+            font-size: .8rem;
+            font-weight: 600;
+        }
+
+        .awx-node-status {
+            font-size: .7rem;
+        }
+
+        .awx-pulse {
+            animation: awx-pulse 1.5s ease-in-out infinite;
+        }
+
+        @keyframes awx-pulse {
+            0% { opacity: 1; }
+            50% { opacity: 0.3; }
+            100% { opacity: 1; }
+        }
+    }
+</style>

--- a/client/src/locales/de.js
+++ b/client/src/locales/de.js
@@ -1,4 +1,9 @@
 export default {
+  workflow: {
+    onSuccess: "bei Erfolg",
+    onFailure: "bei Fehler",
+    always: "immer",
+  },
   nav: {
     forms: "Formulare",
     jobs: "Jobs",

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -1,4 +1,9 @@
 export default {
+  workflow: {
+    onSuccess: "on success",
+    onFailure: "on failure",
+    always: "always",
+  },
   nav: {
     forms: "Forms",
     jobs: "Jobs",

--- a/client/src/locales/es.js
+++ b/client/src/locales/es.js
@@ -1,4 +1,9 @@
 export default {
+  workflow: {
+    onSuccess: "en caso de éxito",
+    onFailure: "en caso de fallo",
+    always: "siempre",
+  },
   nav: {
     forms: "Formularios",
     jobs: "Trabajos",

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -1,4 +1,9 @@
 export default {
+  workflow: {
+    onSuccess: "en cas de succès",
+    onFailure: "en cas d'échec",
+    always: "toujours",
+  },
   nav: {
     forms: "Formulaires",
     jobs: "Jobs",

--- a/client/src/locales/it.js
+++ b/client/src/locales/it.js
@@ -1,4 +1,9 @@
 export default {
+  workflow: {
+    onSuccess: "in caso di successo",
+    onFailure: "in caso di errore",
+    always: "sempre",
+  },
   nav: {
     forms: "Moduli",
     jobs: "Job",

--- a/client/src/locales/nl.js
+++ b/client/src/locales/nl.js
@@ -1,4 +1,9 @@
 export default {
+  workflow: {
+    onSuccess: "bij succes",
+    onFailure: "bij fout",
+    always: "altijd",
+  },
   nav: {
     forms: "Formulieren",
     jobs: "Taken",

--- a/client/src/pages/form.vue
+++ b/client/src/pages/form.vue
@@ -1909,6 +1909,12 @@ onBeforeUnmount(() => {
           <template #default>{{ t('form.applyFilter') }}</template>
           <template #toggle>{{ t('form.removeFilter') }}</template>
         </BsButton>
+        <!-- awx workflow graph (only for awx workflow jobs) -->
+        <div class="row" v-if="job.awx_workflow?.nodes?.length">
+          <div class="col">
+            <AppAwxWorkflow :workflow="job.awx_workflow" />
+          </div>
+        </div>
         <div class="row">
           <div class="col">
             <AppAnsibleOutput :output="filteredJobOutput" :jobLog="job.job_log">

--- a/client/src/pages/jobs.vue
+++ b/client/src/pages/jobs.vue
@@ -809,6 +809,13 @@
                         >{{ t('jobs.applyFilter') }}<template #toggle>{{ t('jobs.removeFilter') }}</template></BsButton>
                     <BsButton @click="download(jobId)" icon="download" cssClass="btn-sm me-2 fw-normal">{{ t('jobs.downloadJob') }}</BsButton>
 
+                    <!-- awx workflow graph (only for awx workflow jobs) -->
+                    <div class="row mt-4" v-if="job.awx_workflow?.nodes?.length">
+                        <div class="col">
+                            <AppAwxWorkflow :workflow="job.awx_workflow" />
+                        </div>
+                    </div>
+
                     <div class="row mt-4">
                         <div class="col">
                             <AppAnsibleOutput :output="filteredJobOutput" :jobLog="job?.job_log">

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "dev": "NODE_ENV=development nodemon --watch src --watch schema --watch config ./index.js",
     "prod": "NODE_ENV=production npm-run-all build server",
     "copyviews": "mkdir -p ./dist/views && cp -R ../client/dist/* ./dist/views/",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@outlinewiki/passport-azure-ad-oauth2": "~0.1.0",

--- a/server/src/db/create_schema_and_tables.sql
+++ b/server/src/db/create_schema_and_tables.sql
@@ -112,6 +112,7 @@ CREATE TABLE `jobs` (
   `parent_id` int(11) DEFAULT NULL,
   `awx_id` int(11) DEFAULT NULL,
   `awx_artifacts` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `awx_workflow` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=47 DEFAULT CHARSET=utf8;
 CREATE TABLE `job_output` (

--- a/server/src/lib/common.js
+++ b/server/src/lib/common.js
@@ -188,7 +188,16 @@ Helpers.formatOutput = (records,asText)=>{
           line = "<span class='has-text-danger'>"+line+"</span>"
         }
       }else{ // regular output stream
-        if(line.match(/^\[WARNING\].*/g)){ // warnings
+        if(line.match(/^WORKFLOW( NODE)? \[.*\] \([a-z_ ]+\).*$/)){ // awx workflow (node) status lines
+          previousformat=""
+          matchfound=true
+          var statusclass=""
+          if(line.match(/\(successful\)/)) statusclass=" has-text-success"
+          else if(line.match(/\((failed|error)\)/)) statusclass=" has-text-danger"
+          else if(line.match(/\(canceled\)/)) statusclass=" has-text-warning"
+          else if(line.match(/\((skipped|pending|waiting)\)/)) statusclass=" has-text-info"
+          line = `<span class='has-text-weight-bold${statusclass}'>`+line+"</span>"
+        }else if(line.match(/^\[WARNING\].*/g)){ // warnings
           previousformat="warning"
           matchfound=true
           line = "<span class='has-text-warning'>"+line+"</span>"

--- a/server/src/models/job.model.js
+++ b/server/src/models/job.model.js
@@ -523,11 +523,11 @@ Job.findById = async function (user, id, asText, logSafe = false) {
   
   if (user.roles.includes("admin") || user.options?.showAllJobLogs) {
     query =
-      "SELECT j.id,j.form,j.target,j.status,CONVERT_TZ(j.start, 'UTC', ?) AS start,CONVERT_TZ(j.end, 'UTC', ?) AS end,j.user,j.user_type,j.job_type,j.extravars,j.credentials,j.notifications,j.approval,j.step,j.parent_id,j.awx_id,j.awx_artifacts,j.abort_requested,j.raw_form_data,sj.subjobs,j2.no_of_records,o.counter FROM AnsibleForms.jobs j LEFT JOIN (SELECT parent_id,GROUP_CONCAT(id separator ',') subjobs FROM AnsibleForms.jobs GROUP BY parent_id) sj ON sj.parent_id=j.id,(SELECT COUNT(id) no_of_records FROM AnsibleForms.jobs)j2,(SELECT max(`order`)+1 counter FROM AnsibleForms.job_output WHERE job_output.job_id=?)o WHERE j.id=?;";
+      "SELECT j.id,j.form,j.target,j.status,CONVERT_TZ(j.start, 'UTC', ?) AS start,CONVERT_TZ(j.end, 'UTC', ?) AS end,j.user,j.user_type,j.job_type,j.extravars,j.credentials,j.notifications,j.approval,j.step,j.parent_id,j.awx_id,j.awx_artifacts,j.awx_workflow,j.abort_requested,j.raw_form_data,sj.subjobs,j2.no_of_records,o.counter FROM AnsibleForms.jobs j LEFT JOIN (SELECT parent_id,GROUP_CONCAT(id separator ',') subjobs FROM AnsibleForms.jobs GROUP BY parent_id) sj ON sj.parent_id=j.id,(SELECT COUNT(id) no_of_records FROM AnsibleForms.jobs)j2,(SELECT max(`order`)+1 counter FROM AnsibleForms.job_output WHERE job_output.job_id=?)o WHERE j.id=?;";
     params = [safeTimezone, safeTimezone, id, id];
   } else {
     query =
-      "SELECT j.id,j.form,j.target,j.status,CONVERT_TZ(j.start, 'UTC', ?) AS start,CONVERT_TZ(j.end, 'UTC', ?) AS end,j.user,j.user_type,j.job_type,j.extravars,j.credentials,j.notifications,j.approval,j.step,j.parent_id,j.awx_id,j.awx_artifacts,j.abort_requested,j.raw_form_data,sj.subjobs,j2.no_of_records,o.counter FROM AnsibleForms.jobs j LEFT JOIN (SELECT parent_id,GROUP_CONCAT(id separator ',') subjobs FROM AnsibleForms.jobs GROUP BY parent_id) sj ON sj.parent_id=j.id,(SELECT COUNT(id) no_of_records FROM AnsibleForms.jobs WHERE user=? AND user_type=?)j2,(SELECT max(`order`)+1 counter FROM AnsibleForms.job_output WHERE job_output.job_id=?)o WHERE j.id=? AND ((j.user=? AND j.user_type=?) OR (j.status='approve'));";
+      "SELECT j.id,j.form,j.target,j.status,CONVERT_TZ(j.start, 'UTC', ?) AS start,CONVERT_TZ(j.end, 'UTC', ?) AS end,j.user,j.user_type,j.job_type,j.extravars,j.credentials,j.notifications,j.approval,j.step,j.parent_id,j.awx_id,j.awx_artifacts,j.awx_workflow,j.abort_requested,j.raw_form_data,sj.subjobs,j2.no_of_records,o.counter FROM AnsibleForms.jobs j LEFT JOIN (SELECT parent_id,GROUP_CONCAT(id separator ',') subjobs FROM AnsibleForms.jobs GROUP BY parent_id) sj ON sj.parent_id=j.id,(SELECT COUNT(id) no_of_records FROM AnsibleForms.jobs WHERE user=? AND user_type=?)j2,(SELECT max(`order`)+1 counter FROM AnsibleForms.job_output WHERE job_output.job_id=?)o WHERE j.id=? AND ((j.user=? AND j.user_type=?) OR (j.status='approve'));";
     params = [safeTimezone, safeTimezone, user.username, user.type, id, id, user.username, user.type];
   }
   try {
@@ -539,6 +539,8 @@ Job.findById = async function (user, id, asText, logSafe = false) {
     var job = res[0];
     // convert artifacts
     job.awx_artifacts = safeParse(job.awx_artifacts, {}, `job.awx_artifacts id=${id}`);
+    // convert awx workflow info (null when not a workflow job)
+    job.awx_workflow = safeParse(job.awx_workflow, null, `job.awx_workflow id=${id}`);
     // mask passwords
     if (logSafe) job.extravars = Helpers.logSafe(job.extravars);
     // get output summary
@@ -1801,16 +1803,18 @@ Ansible.launch = async (
 
 // awx stuff, interaction with awx
 var Awx = function () {};
-Awx.abortJob = async function (awxName, id) {
+Awx.abortJob = async function (awxName, id, isWorkflow = false) {
   const awxConfig = awxName
     ? await AwxModel.findByName(awxName)
     : await AwxModel.findByProperty("is_default", 1);
   if (!awxConfig) throw new Errors.ApiError("Failed to get AWX configuration");
-  logger.info(`aborting awx job ${id}`);
+  logger.info(`aborting awx ${isWorkflow ? "workflow " : ""}job ${id}`);
   const axiosConfig = AwxModel.getAuthorization(awxConfig);
+  // workflow jobs have their own cancel endpoint
+  const jobsPath = isWorkflow ? "/workflow_jobs/" : "/jobs/";
   try {
     const axiosResult = await axios.post(
-      awxConfig.uri + appConfig.awxApiPrefix + "/jobs/" + id + "/cancel/",
+      awxConfig.uri + appConfig.awxApiPrefix + jobsPath + id + "/cancel/",
       {},
       axiosConfig
     );
@@ -2116,6 +2120,10 @@ Awx.trackJob = async function (
   lastrun = false,
   retryCount = 0
 ) {
+  // workflow jobs have no stdout of their own, we track them node by node
+  if (job.type === "workflow_job" || job.related?.workflow_nodes) {
+    return Awx.trackWorkflowJob(awxName, job, jobid, counter);
+  }
   const awxConfig = awxName
     ? await AwxModel.findByName(awxName)
     : await AwxModel.findByProperty("is_default", 1);
@@ -2306,6 +2314,207 @@ Awx.trackJob = async function (
   } catch (e) {
     logger.error("Failed to track job : ", e);
     return e.message;
+  }
+};
+// format a workflow (node) status line ; Helpers.formatOutput() colors these by status
+function workflowStatusLine(prefix, name, status, banner = false) {
+  var line = `${prefix} [${name}] (${status})`;
+  if (banner) line += " " + "*".repeat(Math.max(5, 79 - line.length));
+  return line;
+}
+// get the nodes of an awx workflow job, simplified to what we need for output and visualization
+Awx.getWorkflowNodes = async function (awxName, job) {
+  const awxConfig = awxName
+    ? await AwxModel.findByName(awxName)
+    : await AwxModel.findByProperty("is_default", 1);
+  if (!awxConfig) throw new Errors.ApiError("Failed to get AWX configuration");
+  if (!job.related?.workflow_nodes) return [];
+  const axiosConfig = AwxModel.getAuthorization(awxConfig);
+  var results = [];
+  var url = job.related.workflow_nodes;
+  // the node list is paginated, follow the next links
+  while (url) {
+    const axiosResult = await axios.get(awxConfig.uri + url, axiosConfig);
+    results = results.concat(axiosResult.data?.results || []);
+    url = axiosResult.data?.next;
+  }
+  return results.map((n) => ({
+    id: n.id,
+    name:
+      n.summary_fields?.job?.name ||
+      n.summary_fields?.unified_job_template?.name ||
+      `node ${n.id}`,
+    type:
+      n.summary_fields?.job?.type ||
+      n.summary_fields?.unified_job_template?.unified_job_type ||
+      "job",
+    status:
+      n.summary_fields?.job?.status || (n.do_not_run ? "skipped" : "pending"),
+    elapsed: n.summary_fields?.job?.elapsed || 0,
+    job: n.job,
+    job_url: n.related?.job,
+    success_nodes: n.success_nodes || [],
+    failure_nodes: n.failure_nodes || [],
+    always_nodes: n.always_nodes || [],
+    do_not_run: n.do_not_run || false,
+  }));
+};
+// track an awx workflow job ; poll the workflow nodes, dump the output of every
+// finished node and store the workflow graph as json for visualization
+Awx.trackWorkflowJob = async function (
+  awxName,
+  job,
+  jobid,
+  counter,
+  printedNodeIds = [],
+  previousWorkflowJson = "",
+  retryCount = 0
+) {
+  const awxConfig = awxName
+    ? await AwxModel.findByName(awxName)
+    : await AwxModel.findByProperty("is_default", 1);
+  if (!awxConfig) throw new Error("Failed to get AWX configuration");
+  const axiosConfig = AwxModel.getAuthorization(awxConfig);
+  try {
+    // get workflow job info
+    const axiosResult = await axios.get(awxConfig.uri + job.url, axiosConfig);
+    var j = axiosResult.data;
+    if (!j) throw new Error(`could not find workflow job with id ${job.id}`);
+    logger.debug(`awx workflow job status : ` + j.status);
+    // get the workflow nodes
+    const nodes = await Awx.getWorkflowNodes(awxName, j);
+    // store the workflow graph json, the client uses this to visualize the workflow
+    const workflowJson = JSON.stringify({
+      id: j.id,
+      name: j.name,
+      status: j.status,
+      nodes,
+    });
+    if (workflowJson != previousWorkflowJson) {
+      await Job.update({ awx_workflow: workflowJson }, jobid);
+    }
+    // dump the output of the nodes that just finished (in completion order)
+    const finishedStatuses = ["successful", "failed", "error", "canceled"];
+    const finishedNodes = nodes.filter(
+      (n) =>
+        n.job &&
+        finishedStatuses.includes(n.status) &&
+        !printedNodeIds.includes(n.id)
+    );
+    for (const node of finishedNodes) {
+      var nodeOutput = "";
+      try {
+        // get the child job (job, project_update, workflow_approval, ...) and grab its output
+        const childResult = await axios.get(
+          awxConfig.uri + node.job_url,
+          axiosConfig
+        );
+        nodeOutput =
+          (await Awx.getJobTextOutput(awxName, childResult.data)) || "";
+      } catch (e) {
+        logger.warning(
+          `Failed to get output of workflow node ${node.name} : ${e.message}`
+        );
+      }
+      const banner = workflowStatusLine(
+        "WORKFLOW NODE",
+        node.name,
+        node.status,
+        true
+      );
+      await Job.printJobOutput(
+        `${banner}\n${nodeOutput}`.trim(),
+        "stdout",
+        jobid,
+        ++counter
+      );
+      printedNodeIds.push(node.id);
+    }
+    // check for abort request
+    const abort_requested = await Job.isAbortRequested(jobid);
+    if (abort_requested) {
+      await Job.printJobOutput("Abort requested", "stderr", jobid, ++counter);
+      try {
+        // we try to abort the workflow job
+        await Awx.abortJob(awxName, j.id, true);
+        await Job.resetAbortRequested(jobid);
+        await Job.endJobStatus(
+          jobid,
+          ++counter,
+          "stderr",
+          "aborted",
+          "Aborted workflow job"
+        );
+        return "Aborted workflow job";
+      } catch (error) {
+        // abort failed... , revert abort request
+        await Job.printJobOutput(
+          "Abort request denied, reverting abort request",
+          "stderr",
+          jobid,
+          ++counter
+        );
+        await Job.resetAbortRequested(jobid);
+      }
+    }
+    if (j.finished) {
+      // print a summary of all the nodes with their status
+      var summary = [workflowStatusLine("WORKFLOW", j.name, j.status, true)];
+      nodes.forEach((node) => {
+        summary.push(workflowStatusLine("WORKFLOW NODE", node.name, node.status));
+      });
+      await Job.printJobOutput(summary.join("\n"), "stdout", jobid, ++counter);
+      if (j.status === "successful") {
+        await Job.endJobStatus(
+          jobid,
+          ++counter,
+          "stdout",
+          "success",
+          `Successfully completed workflow ${j.name}`
+        );
+        return true;
+      } else {
+        // if error, end with status (aborted or failed)
+        var status = "failed";
+        var message = `Workflow ${j.name} completed with status ${j.status}`;
+        if (j.status == "canceled") {
+          status = "aborted";
+          message = `Workflow ${j.name} was aborted`;
+          await Job.resetAbortRequested(jobid);
+        }
+        await Job.endJobStatus(jobid, ++counter, "stderr", status, message);
+        return message;
+      }
+    }
+    // not finished, try again
+    await delay(1000);
+    return await Awx.trackWorkflowJob(
+      awxName,
+      j,
+      jobid,
+      ++counter,
+      printedNodeIds,
+      workflowJson
+    );
+  } catch (err) {
+    const message = err.toString();
+    logger.error(message);
+    retryCount++;
+    if (retryCount == 10) {
+      return Promise.resolve(message);
+    } else {
+      logger.warning(`Retrying jobid ${jobid} [${retryCount}]`);
+      await delay(1000);
+      return await Awx.trackWorkflowJob(
+        awxName,
+        job,
+        jobid,
+        counter,
+        printedNodeIds,
+        previousWorkflowJson,
+        retryCount
+      );
+    }
   }
 };
 Awx.getJobTextOutput = async function (awxName, job) {
@@ -2535,3 +2744,5 @@ Awx.findInventoryByName = async function (awxName, name) {
 };
 
 export default Job;
+// named export of the awx interaction functions (mainly for testing)
+export { Awx };

--- a/server/src/models/schema.model.js
+++ b/server/src/models/schema.model.js
@@ -474,6 +474,11 @@ async function patchVersion6(messages, success, failed) {
   // Allow user/password to be NULL for vault-backed credentials.
   await checkPromise(makeColumnNullable("credentials", "user", "varchar(250)"), messages, success, failed);
   await checkPromise(makeColumnNullable("credentials", "password", "text"), messages, success, failed);
+
+  // Add awx_workflow column to jobs table (6.3.0)
+  // This stores the awx workflow nodes (name, status, relations) as json,
+  // so the client can visualize the workflow graph of an awx workflow job
+  await checkPromise(addColumn("jobs", "awx_workflow", "longtext", true, "NULL"), messages, success, failed);
 }
 
 // PATCHING : Patch All

--- a/server/tests/awx-workflow.test.mjs
+++ b/server/tests/awx-workflow.test.mjs
@@ -1,0 +1,307 @@
+// integration tests for the awx (workflow) job tracking ; run with `npm test` (node --test)
+// spins up a test awx api and mocks the database, then runs the real
+// Awx.trackJob / Awx.trackWorkflowJob polling loops against it (issue #420)
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "http";
+
+// minimal env so the config modules load without a real setup
+process.env.LOG_PATH = process.env.LOG_PATH || "/tmp/ansibleforms-test-logs";
+process.env.DB_HOST = process.env.DB_HOST || "127.0.0.1";
+process.env.DB_PORT = process.env.DB_PORT || "3306";
+process.env.DB_USER = process.env.DB_USER || "test";
+process.env.DB_PASSWORD = process.env.DB_PASSWORD || "test";
+
+const { default: Job, Awx } = await import("../src/models/job.model.js");
+const { default: mysql } = await import("../src/models/db.model.js");
+const { default: AwxModel } = await import("../src/models/awx.model.js");
+const { default: logger } = await import("../src/lib/logger.js");
+
+/*****************************************************************/
+/* test database                                                 */
+/*****************************************************************/
+var jobRow = {};
+var outputs = [];
+mysql.do = async function (sql, params) {
+  if (sql.includes("INSERT INTO AnsibleForms.`job_output`")) {
+    outputs.push({ ...params[0] });
+    return { insertId: outputs.length };
+  }
+  if (sql.includes("UPDATE AnsibleForms.`jobs` set abort_requested=0")) {
+    jobRow.abort_requested = 0;
+    return { changedRows: 1 };
+  }
+  if (sql.includes("UPDATE AnsibleForms.`jobs` set ?")) {
+    Object.assign(jobRow, params[0]);
+    return { changedRows: 1 };
+  }
+  if (sql.includes("SELECT abort_requested")) {
+    return [{ abort_requested: jobRow.abort_requested || 0 }];
+  }
+  if (sql.includes("SELECT id FROM AnsibleForms.`jobs`")) {
+    return [{ id: params[0] }];
+  }
+  return [];
+};
+// no notifications during tests
+Job.sendStatusNotification = async () => {};
+
+/*****************************************************************/
+/* test awx api                                                  */
+/*****************************************************************/
+var awxState = {};
+var cancelCalls = [];
+
+function resetState() {
+  jobRow = {};
+  outputs = [];
+  cancelCalls = [];
+  awxState = {
+    wfPoll: 0, // number of times the workflow job was polled
+    wfFinalStatus: "successful",
+    jobPoll: 0, // number of times the regular job was polled
+    abortAfterPoll: 0, // request an ansibleforms abort after this wf poll (0 = never)
+  };
+}
+
+// the node statuses evolve with every workflow poll:
+// poll 1 : node1 running   node2 pending  node3 pending
+// poll 2 : node1 successful node2 running node3 pending
+// poll >= 3 : node1 successful node2 final node3 do_not_run
+function nodeSummaries() {
+  const p = awxState.wfPoll;
+  const node2Final = awxState.wfFinalStatus == "successful" ? "successful" : "failed";
+  return {
+    1: { id: 101, name: "node one", type: "job", status: p >= 2 ? "successful" : "running", elapsed: p >= 2 ? 1.5 : 0 },
+    2: p >= 2 ? { id: 102, name: "node two", type: "job", status: p >= 3 ? node2Final : "running", elapsed: p >= 3 ? 2.5 : 0 } : null,
+    3: null,
+  };
+}
+
+function workflowNodes(page) {
+  const s = nodeSummaries();
+  const all = [
+    {
+      id: 1,
+      job: 101,
+      related: { job: "/api/v2/jobs/101/" },
+      summary_fields: { job: s[1], unified_job_template: { name: "node one", unified_job_type: "job" } },
+      success_nodes: [2],
+      failure_nodes: [3],
+      always_nodes: [],
+      do_not_run: false,
+    },
+    {
+      id: 2,
+      job: s[2] ? 102 : null,
+      related: s[2] ? { job: "/api/v2/jobs/102/" } : {},
+      summary_fields: { job: s[2], unified_job_template: { name: "node two", unified_job_type: "job" } },
+      success_nodes: [],
+      failure_nodes: [],
+      always_nodes: [],
+      do_not_run: false,
+    },
+    {
+      id: 3,
+      job: null,
+      related: {},
+      summary_fields: { unified_job_template: { name: "node three", unified_job_type: "job" } },
+      success_nodes: [],
+      failure_nodes: [],
+      always_nodes: [],
+      do_not_run: awxState.wfPoll >= 3, // awx marks the not taken branch as do_not_run
+    },
+  ];
+  // 2 pages, to test the pagination
+  if (page == 1) return { count: 3, next: "/api/v2/workflow_jobs/1/workflow_nodes/?page=2", results: all.slice(0, 2) };
+  return { count: 3, next: null, results: all.slice(2) };
+}
+
+const server = http.createServer((req, res) => {
+  try {
+    handleRequest(req, res);
+  } catch (e) {
+    // never leave a request hanging, the polling loops would wait forever
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ detail: e.message }));
+  }
+});
+
+function handleRequest(req, res) {
+  if (process.env.TEST_DEBUG) console.log("[test awx]", req.method, req.url);
+  const url = new URL(req.url, "http://localhost");
+  const path = url.pathname;
+  var data = null;
+  if (req.method == "POST" && path.match(/\/cancel\/$/)) {
+    cancelCalls.push(path);
+    res.writeHead(202, { "Content-Type": "application/json" });
+    res.end("{}");
+    return;
+  }
+  if (path == "/api/v2/workflow_jobs/1/") {
+    awxState.wfPoll++;
+    if (awxState.abortAfterPoll && awxState.wfPoll > awxState.abortAfterPoll) {
+      jobRow.abort_requested = 1; // the user clicks abort in ansibleforms
+    }
+    const finished = awxState.wfPoll >= 4;
+    data = {
+      id: 1,
+      type: "workflow_job",
+      name: "my workflow",
+      url: "/api/v2/workflow_jobs/1/",
+      status: finished ? awxState.wfFinalStatus : "running",
+      finished: finished ? "2026-01-01T10:00:00Z" : null,
+      related: { workflow_nodes: "/api/v2/workflow_jobs/1/workflow_nodes/", cancel: "/api/v2/workflow_jobs/1/cancel/" },
+    };
+  } else if (path == "/api/v2/workflow_jobs/1/workflow_nodes/") {
+    data = workflowNodes(parseInt(url.searchParams.get("page") || "1"));
+  } else if (path.match(/^\/api\/v2\/jobs\/10[12]\/$/)) {
+    const id = parseInt(path.match(/jobs\/(\d+)\//)[1]);
+    const s = nodeSummaries()[id - 100];
+    data = { id, type: "job", url: path, status: s.status, related: { stdout: `/api/v2/jobs/${id}/stdout/` } };
+  } else if (path.match(/^\/api\/v2\/jobs\/10[12]\/stdout\/$/)) {
+    const id = parseInt(path.match(/jobs\/(\d+)\//)[1]);
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(`PLAY [node ${id}] ${"*".repeat(40)}\nok: [localhost${id}]`);
+    return;
+  } else if (path == "/api/v2/jobs/55/") {
+    // a regular (non workflow) job, finished on the 2nd poll
+    awxState.jobPoll++;
+    const finished = awxState.jobPoll >= 2;
+    data = {
+      id: 55,
+      type: "job",
+      name: "regular template",
+      url: "/api/v2/jobs/55/",
+      status: finished ? "successful" : "running",
+      finished: finished ? "2026-01-01T10:00:00Z" : null,
+      artifacts: { myfact: "myvalue" },
+      related: { stdout: "/api/v2/jobs/55/stdout/" },
+    };
+  } else if (path == "/api/v2/jobs/55/stdout/") {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(awxState.jobPoll >= 2 ? "line one\nline two" : "line one");
+    return;
+  }
+  if (data) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(data));
+  } else {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ detail: "Not found: " + path }));
+  }
+}
+
+before(async () => {
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const uri = `http://127.0.0.1:${server.address().port}`;
+  // test awx config
+  AwxModel.findByName = async () => ({ name: "myawx", uri });
+  AwxModel.findByProperty = async () => ({ name: "myawx", uri });
+  AwxModel.getAuthorization = () => ({});
+});
+after(() => {
+  // drop keep-alive sockets and the logger file streams, so the test process can exit
+  server.closeAllConnections();
+  server.close();
+  logger.close();
+});
+beforeEach(resetState);
+
+// the launch response of a workflow job template, as trackJob receives it
+function workflowLaunchJob() {
+  return {
+    id: 1,
+    type: "workflow_job",
+    url: "/api/v2/workflow_jobs/1/",
+    status: "pending",
+    related: { workflow_nodes: "/api/v2/workflow_jobs/1/workflow_nodes/", cancel: "/api/v2/workflow_jobs/1/cancel/" },
+  };
+}
+
+function allOutput() {
+  return outputs.map((o) => o.output).join("\n");
+}
+
+/*****************************************************************/
+/* tests                                                         */
+/*****************************************************************/
+
+test("successful workflow job: node outputs, summary and graph json", { timeout: 30000 }, async () => {
+  awxState.wfFinalStatus = "successful";
+  const result = await Awx.trackJob("myawx", workflowLaunchJob(), 7, 0);
+  assert.equal(result, true);
+  assert.equal(jobRow.status, "success");
+  const out = allOutput();
+  // every node banner exactly once, with the output of the child job below it
+  assert.equal(out.match(/WORKFLOW NODE \[node one\] \(successful\) \*+/g).length, 1);
+  assert.equal(out.match(/WORKFLOW NODE \[node two\] \(successful\) \*+/g).length, 1);
+  assert.match(out, /ok: \[localhost101\]/);
+  assert.match(out, /ok: \[localhost102\]/);
+  // the summary with all the nodes
+  assert.match(out, /WORKFLOW \[my workflow\] \(successful\) \*+/);
+  assert.match(out, /WORKFLOW NODE \[node three\] \(skipped\)/);
+  assert.match(out, /Successfully completed workflow my workflow/);
+  // the graph json is stored and holds the final node statuses
+  const graph = JSON.parse(jobRow.awx_workflow);
+  assert.equal(graph.name, "my workflow");
+  assert.equal(graph.status, "successful");
+  assert.equal(graph.nodes.length, 3); // pagination followed
+  assert.equal(graph.nodes.find((n) => n.id == 1).status, "successful");
+  assert.equal(graph.nodes.find((n) => n.id == 1).name, "node one");
+  assert.deepEqual(graph.nodes.find((n) => n.id == 1).success_nodes, [2]);
+  assert.equal(graph.nodes.find((n) => n.id == 3).status, "skipped");
+  // the output order is strictly increasing
+  const orders = outputs.map((o) => o.order);
+  assert.deepEqual(orders, [...orders].sort((a, b) => a - b));
+  assert.equal(new Set(orders).size, orders.length);
+});
+
+test("failed workflow job: failed node and failed job status", { timeout: 30000 }, async () => {
+  awxState.wfFinalStatus = "failed";
+  const result = await Awx.trackJob("myawx", workflowLaunchJob(), 7, 0);
+  assert.match(result, /completed with status failed/);
+  assert.equal(jobRow.status, "failed");
+  const out = allOutput();
+  assert.equal(out.match(/WORKFLOW NODE \[node two\] \(failed\) \*+/g).length, 1);
+  assert.match(out, /WORKFLOW \[my workflow\] \(failed\) \*+/);
+  const graph = JSON.parse(jobRow.awx_workflow);
+  assert.equal(graph.status, "failed");
+  assert.equal(graph.nodes.find((n) => n.id == 2).status, "failed");
+});
+
+test("aborting a workflow job cancels it on the workflow endpoint", { timeout: 30000 }, async () => {
+  awxState.abortAfterPoll = 1;
+  const result = await Awx.trackJob("myawx", workflowLaunchJob(), 7, 0);
+  assert.equal(result, "Aborted workflow job");
+  assert.equal(jobRow.status, "aborted");
+  assert.deepEqual(cancelCalls, ["/api/v2/workflow_jobs/1/cancel/"]);
+  assert.equal(jobRow.abort_requested, 0); // reset after the abort
+});
+
+test("regular (non workflow) job tracking is unchanged", { timeout: 30000 }, async () => {
+  const launchJob = {
+    id: 55,
+    type: "job",
+    url: "/api/v2/jobs/55/",
+    status: "pending",
+    related: { stdout: "/api/v2/jobs/55/stdout/" },
+  };
+  const result = await Awx.trackJob("myawx", launchJob, 8, 0);
+  assert.equal(result, true);
+  assert.equal(jobRow.status, "success");
+  assert.deepEqual(JSON.parse(jobRow.awx_artifacts), { myfact: "myvalue" });
+  assert.equal(jobRow.awx_workflow, undefined); // no graph for regular jobs
+  const out = allOutput();
+  assert.match(out, /line one/);
+  assert.match(out, /line two/);
+  assert.match(out, /Successfully completed template regular template/);
+  // the incremental output must not duplicate lines
+  assert.equal(out.match(/line one/g).length, 1);
+});
+
+test("abortJob hits the jobs endpoint by default and workflow_jobs for workflows", async () => {
+  await Awx.abortJob("myawx", 55);
+  await Awx.abortJob("myawx", 1, true);
+  assert.deepEqual(cancelCalls, ["/api/v2/jobs/55/cancel/", "/api/v2/workflow_jobs/1/cancel/"]);
+});

--- a/server/tests/format-output.test.mjs
+++ b/server/tests/format-output.test.mjs
@@ -1,0 +1,85 @@
+// tests for Helpers.formatOutput ; run with `npm test` (node --test)
+// covers the classic ansible output coloring (regression) and the
+// awx workflow status lines coloring (issue #420)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// minimal env so the config modules load without a real setup
+process.env.LOG_PATH = process.env.LOG_PATH || "/tmp/ansibleforms-test-logs";
+process.env.DB_HOST = process.env.DB_HOST || "127.0.0.1";
+process.env.DB_PORT = process.env.DB_PORT || "3306";
+process.env.DB_USER = process.env.DB_USER || "test";
+process.env.DB_PASSWORD = process.env.DB_PASSWORD || "test";
+
+const { default: Helpers } = await import("../src/lib/common.js");
+
+function record(output, output_type = "stdout", timestamp = "2026-01-01 10:00:00") {
+  return { output, output_type, timestamp };
+}
+
+test("classic ansible output coloring is unchanged", () => {
+  const out = Helpers.formatOutput(
+    [
+      record("PLAY [all] " + "*".repeat(64)),
+      record("TASK [copy] " + "*".repeat(60) + "\nok: [host1]\nchanged: [host2]\nskipping: [host3]"),
+      record("[WARNING]: something odd"),
+      record("[ERROR]: something bad"),
+      record("fatal: [host3]: FAILED! => {\"msg\": \"boom\"}", "stderr"),
+      record("localhost : ok=2 changed=1 unreachable=0 failed=1 skipped=1"),
+    ],
+    false
+  );
+  assert.match(out, /has-text-weight-bold'>PLAY \[all\]/);
+  assert.match(out, /has-text-success'>ok: \[host1\]/);
+  assert.match(out, /has-text-warning'>changed: \[host2\]/);
+  assert.match(out, /has-text-info'>skipping: \[host3\]/);
+  assert.match(out, /has-text-warning'>\[WARNING\]: something odd/);
+  assert.match(out, /has-text-danger'>\[ERROR\]: something bad/);
+  assert.match(out, /has-text-danger'>fatal: \[host3\]/);
+  assert.match(out, /tag is-success'>ok=2/);
+  assert.match(out, /tag is-warning'>failed=1/);
+});
+
+test("workflow node status lines are colored by status", () => {
+  const out = Helpers.formatOutput(
+    [
+      record("WORKFLOW NODE [node one] (successful) " + "*".repeat(40)),
+      record("WORKFLOW NODE [node two] (failed)"),
+      record("WORKFLOW NODE [node three] (error)"),
+      record("WORKFLOW NODE [node four] (canceled)"),
+      record("WORKFLOW NODE [node five] (skipped)"),
+      record("WORKFLOW NODE [node six] (pending)"),
+      record("WORKFLOW NODE [node seven] (running)"),
+      record("WORKFLOW [my workflow] (failed) " + "*".repeat(40)),
+    ],
+    false
+  );
+  assert.match(out, /has-text-weight-bold has-text-success'>WORKFLOW NODE \[node one\] \(successful\)/);
+  assert.match(out, /has-text-weight-bold has-text-danger'>WORKFLOW NODE \[node two\] \(failed\)/);
+  assert.match(out, /has-text-weight-bold has-text-danger'>WORKFLOW NODE \[node three\] \(error\)/);
+  assert.match(out, /has-text-weight-bold has-text-warning'>WORKFLOW NODE \[node four\] \(canceled\)/);
+  assert.match(out, /has-text-weight-bold has-text-info'>WORKFLOW NODE \[node five\] \(skipped\)/);
+  assert.match(out, /has-text-weight-bold has-text-info'>WORKFLOW NODE \[node six\] \(pending\)/);
+  // running has no status color, just bold
+  assert.match(out, /has-text-weight-bold'>WORKFLOW NODE \[node seven\] \(running\)/);
+  // the workflow summary line itself
+  assert.match(out, /has-text-weight-bold has-text-danger'>WORKFLOW \[my workflow\] \(failed\)/);
+});
+
+test("workflow banner does not bleed its color into the next lines", () => {
+  const out = Helpers.formatOutput(
+    [record("WORKFLOW NODE [node one] (failed) " + "*".repeat(40) + "\nplain output line")],
+    false
+  );
+  // the plain line after the banner must not be red
+  assert.match(out, /<span class=''>plain output line<\/span>/);
+});
+
+test("workflow lines stay plain in text mode (download)", () => {
+  const out = Helpers.formatOutput(
+    [record("WORKFLOW NODE [node one] (successful) ****")],
+    true
+  );
+  assert.equal(out.includes("<span"), false);
+  assert.match(out, /WORKFLOW NODE \[node one\] \(successful\)/);
+});


### PR DESCRIPTION
## Summary

Fixes #420 — when a form targets an AWX **workflow job template**, AnsibleForms showed no output of the workflow's child jobs (just the workflow status).

This PR tracks workflow jobs node by node and:

- **Combined output**: when a workflow node finishes, the output of its child job (job, project update, approval, …) is appended to the job output, prefixed with a `WORKFLOW NODE [name] (status)` banner — **green** for successful, **red** for failed/error, yellow for canceled, blue for skipped/pending. A final summary block lists every node with its colored status.
- **AWX-style workflow graph**: the workflow node graph (names, statuses, success/failure/always relations) is stored as JSON in a new `jobs.awx_workflow` column (with schema patch) and refreshed on every poll. A new `AppAwxWorkflow` Vue component renders it above the job output on the form and jobs pages, similar to the AWX workflow visualizer: a START node, links colored by relation (success=green, failure=red, always=blue) and nodes painted by status (green=successful, red=failed, pulsing blue=running, dashed=skipped/do-not-run), with a legend, elapsed time per node and live updates while the workflow runs. Wide workflows scroll horizontally inside the card.
- **Abort support**: aborting a workflow job now cancels it via the AWX `workflow_jobs/<id>/cancel/` endpoint (regular jobs keep using `jobs/<id>/cancel/`).

## Implementation notes

- `Awx.trackJob` delegates to a new `Awx.trackWorkflowJob` when the launched job is a `workflow_job`; regular job tracking is untouched.
- `Awx.getWorkflowNodes` follows the AWX pagination of `workflow_nodes` and reduces each node to what is needed for output and visualization.
- Child job output is fetched through the node's type-aware `related.job` url, so project updates and approvals work too; nested workflows show their status (not recursed into, for now).
- The node graph JSON is only written when it changed, and `Job.findById` returns it parsed as `awx_workflow`.
- New i18n keys (`workflow.*`) added to all six locales.

## Tests

`npm test` in `server/` (plain `node:test`, no new dependencies):

- Integration tests that run the real tracking loops against AWX: successful workflow, failed workflow, abort via the workflow cancel endpoint, and a regression test proving regular (non-workflow) job tracking is unchanged.
- Formatting tests for the workflow status line coloring, plus a regression test for the classic ansible output coloring (`ok:`/`changed:`/`skipping:`/recap tags etc. unchanged).

The client builds cleanly with `vite build`.