### PR TITLE
Host AnsibleForms under a URL subpath with BASE_URL (fixes #106)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,9 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" href="/favicon.svg" />
+  <!-- the server rewrites this base tag at runtime when BASE_URL is set (subpath hosting) -->
+  <base href="/" />
+  <link rel="icon" href="favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ansible Forms</title>
   <style>
@@ -13,7 +15,19 @@
       height: 100vh;
     }
   </style>
-  <link rel="stylesheet" href="/css/themes.css" />
+  <script>
+    // resolve the public login background images against the base tag, so they
+    // follow the subpath the app is hosted under (relative urls in css custom
+    // properties are unreliable across browsers, so we make them absolute here)
+    (function () {
+      var style = document.documentElement.style;
+      ['light', 'dark', 'color'].forEach(function (theme) {
+        style.setProperty('--af-login-background-' + theme,
+          'url(' + new URL('img/login_background_' + theme + '.jpg', document.baseURI) + ')');
+      });
+    })();
+  </script>
+  <link rel="stylesheet" href="css/themes.css" />
 </head>
 
 <body>

--- a/client/src/components/BsNavBar.vue
+++ b/client/src/components/BsNavBar.vue
@@ -24,9 +24,9 @@
   <nav class="navbar navbar-expand-md border border-secondary-subtle border-top-0 border-start-0 border-end-0 border-bottom-1 py-3">
     <div class="container-xxl">
       <router-link class="navbar-brand ms-3" to="/">
-        <img class="logo my-auto" v-if="currentTheme === 'dark'" src="/img/logo_dark.svg" />
-        <img class="logo my-auto" v-else-if="currentTheme === 'light'" src="/img/logo_light.svg" />
-        <img class="logo my-auto" v-else src="/img/logo_color.svg" />
+        <img class="logo my-auto" v-if="currentTheme === 'dark'" :src="'img/logo_dark.svg'" />
+        <img class="logo my-auto" v-else-if="currentTheme === 'light'" :src="'img/logo_light.svg'" />
+        <img class="logo my-auto" v-else :src="'img/logo_color.svg'" />
       </router-link>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse"
         aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">

--- a/client/src/lib/BaseUrl.js
+++ b/client/src/lib/BaseUrl.js
@@ -1,0 +1,7 @@
+// The runtime base path of the app, for subpath hosting behind a reverse proxy.
+// The server rewrites the <base href="/"> tag in index.html to the configured
+// BASE_URL (e.g. "/ansibleforms/"), we derive the base path from it at runtime.
+// Result: "" for root hosting, or "/subpath" (leading slash, no trailing slash).
+const BaseUrl = new URL(document.baseURI).pathname.replace(/\/+$/, "");
+
+export default BaseUrl;

--- a/client/src/pages/api-docs.vue
+++ b/client/src/pages/api-docs.vue
@@ -31,8 +31,8 @@
             <div class="bg-light p-3 rounded border mb-3">
               <div class="mb-2">API Docs Endpoints:</div>
               <pre class="mb-0" style="font-family: 'Fira Mono', 'Consolas', monospace; background: none; border: none;">
-<a href="/api/v1/docs">/api/v1/docs</a> <span class="text-warning">(deprecated)</span>
-<a href="/api/v2/docs">/api/v2/docs</a> <span class="text-success">(recommended)</span>
+<a href="api/v1/docs">/api/v1/docs</a> <span class="text-warning">(deprecated)</span>
+<a href="api/v2/docs">/api/v2/docs</a> <span class="text-success">(recommended)</span>
               </pre>
             </div>
             <p class="mb-0 text-muted">

--- a/client/src/pages/change-password.vue
+++ b/client/src/pages/change-password.vue
@@ -141,19 +141,19 @@ const $v = useVuelidate(rules, { item });
 
 [data-bs-theme="light"] {
   .login {
-    background-image: url(/img/login_background_light.jpg) !important;
+    background-image: var(--af-login-background-light) !important;
     background-size: cover;
   }
 }
 [data-bs-theme="dark"] {
   .login {
-    background-image: url(/img/login_background_dark.jpg) !important;
+    background-image: var(--af-login-background-dark) !important;
     background-size: cover;
   }
 }
 [data-bs-theme="color"] {
   .login {
-    background-image: url(/img/login_background_color.jpg) !important;
+    background-image: var(--af-login-background-color) !important;
     background-size: cover;
   }
 }

--- a/client/src/pages/error.vue
+++ b/client/src/pages/error.vue
@@ -26,16 +26,16 @@ const errorMessageHtml = computed(() =>
                             <li>Login as local admin</li>
                             <li>
                                 Double check your environment variables.
-                                <a class="btn btn-sm btn-secondary ms-2" href="/admin/settings">Settings</a>
+                                <router-link class="btn btn-sm btn-secondary ms-2" to="/admin/settings">Settings</router-link>
                             </li>
                             <li>
                                 Check the logfiles.
-                                <a class="btn btn-sm btn-secondary ms-2" href="/logs">Logs</a>
+                                <router-link class="btn btn-sm btn-secondary ms-2" to="/logs">Logs</router-link>
                             </li>
                             <li>
                                 Make sure you have a valid config.yaml file (or legacy forms.yaml).<br>
                                 Or make a repository to host your forms.
-                                <a class="btn btn-sm btn-success ms-2" href="/admin/repositories">Create repository</a>
+                                <router-link class="btn btn-sm btn-success ms-2" to="/admin/repositories">Create repository</router-link>
                             </li>
                             <li>Double check firewalls, hostname, username and password</li>
                         </ol>

--- a/client/src/pages/login.vue
+++ b/client/src/pages/login.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from "vue";
 import { useVuelidate } from "@vuelidate/core";
 import { required } from "@vuelidate/validators";
 import TokenStorage from "@/lib/TokenStorage"; // work with tokens and local storage
+import BaseUrl from '@/lib/BaseUrl';
 import State from "@/lib/State"; // work with state
 import Navigate from "@/lib/Navigate"; // navigate to routes
 import Helpers from "@/lib/Helpers"; // helper functions
@@ -50,11 +51,11 @@ const $v = useVuelidate(rules, { user });
 // methods
 function authAzureAd() {
    localStorage.setItem("authIssuer", "azuread");  // set cookie to azuread
-   window.location.replace(`/api/v2/auth/azureadoauth2`) // redirect to azuread
+   window.location.replace(`${BaseUrl}/api/v2/auth/azureadoauth2`) // redirect to azuread
 }
 function authOidc() {
    localStorage.setItem("authIssuer", "oidc");   // set cookie to oidc
-   window.location.replace(`/api/v2/auth/oidc`) // redirect to oidc
+   window.location.replace(`${BaseUrl}/api/v2/auth/oidc`) // redirect to oidc
 }
 function getGroupsAndLogin(token, url = `${azureGraphUrl.value}/v1.0/me/transitiveMemberOf`, type = 'azuread', allGroups = []) {
    if (type === 'azuread') {
@@ -239,19 +240,19 @@ onMounted(() => {
 }
 [data-bs-theme="light"] {
     .login{
-      background-image: url(/img/login_background_light.jpg) !important;
+      background-image: var(--af-login-background-light) !important;
       background-size: cover;
     }
   }
   [data-bs-theme="dark"] {
     .login{
-      background-image: url(/img/login_background_dark.jpg) !important;
+      background-image: var(--af-login-background-dark) !important;
       background-size: cover;
     }
   }
   [data-bs-theme="color"] {
     .login{
-      background-image: url(/img/login_background_color.jpg) !important;
+      background-image: var(--af-login-background-color) !important;
       background-size: cover;
     }
   }  

--- a/client/src/pages/logout.vue
+++ b/client/src/pages/logout.vue
@@ -64,21 +64,21 @@ if (userType == "oidc") {
 <style scoped lang="scss">
 [data-bs-theme="light"] {
     .login {
-        background-image: url(/img/login_background_light.jpg) !important;
+        background-image: var(--af-login-background-light) !important;
         background-size: cover;
     }
 }
 
 [data-bs-theme="dark"] {
     .login {
-        background-image: url(/img/login_background_dark.jpg) !important;
+        background-image: var(--af-login-background-dark) !important;
         background-size: cover;
     }
 }
 
 [data-bs-theme="color"] {
     .login {
-        background-image: url(/img/login_background_color.jpg) !important;
+        background-image: var(--af-login-background-color) !important;
         background-size: cover;
     }
 }

--- a/client/src/pages/schema.vue
+++ b/client/src/pages/schema.vue
@@ -37,7 +37,7 @@ async function create() {
     const createResult = await axios.post(`/api/v2/schema`, {})
     toast.success(createResult.data.message)
     // Full page reload to reinitialize app with new database
-    window.location.href = '/'
+    window.location.href = document.baseURI
   } catch (error) {
     toast.error(error.message)
     loading.value = false
@@ -50,7 +50,7 @@ function startCountdown() {
     countdown.value--
     if (countdown.value <= 0) {
       clearInterval(countdownInterval)
-      window.location.href = '/'
+      window.location.href = document.baseURI
     }
   }, 1000)
 }

--- a/client/src/plugins/index.js
+++ b/client/src/plugins/index.js
@@ -4,6 +4,12 @@
  * Automatically included in `./src/main.js`
  */
 
+// the app can be hosted under a subpath (issue #106), all api calls
+// must be prefixed with the runtime base path (empty for root hosting)
+import axios from 'axios'
+import BaseUrl from '@/lib/BaseUrl'
+axios.defaults.baseURL = BaseUrl
+
 // Plugins
 // import vuetify from './vuetify'
 import pinia from '@/stores'

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -2,6 +2,7 @@
 
 // Composables
 import { createRouter, createWebHistory } from 'vue-router'
+import BaseUrl from '@/lib/BaseUrl'
 
 import designer from "@/pages/designer.vue"
 import index from "@/pages/index.vue"
@@ -122,7 +123,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(`${BaseUrl}/`), // honor the subpath the app is hosted under
   routes
 })
 

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -13,6 +13,9 @@ import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // relative base, so a single build works under any subpath (issue #106)
+  // the server rewrites the <base href="/"> tag in index.html at runtime (BASE_URL)
+  base: './',
   plugins: [
     basicSsl(),
     svgLoader(
@@ -57,7 +60,6 @@ export default defineConfig({
     ],
   },
   build:{
-    base: './',
     minify: 'terser',
     terserOptions: {
       mangle: {

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -109,6 +109,16 @@
     short: Http port
     description: The listening port of the web application
     default: 8000
+  - name: BASE_URL
+    type: string
+    allowed: a url subpath, for example /ansibleforms
+    short: Url subpath to host the application under
+    required: false
+    default: /
+    description: |
+      Host the whole application (gui, rest api and swagger interface) under a url subpath, typically behind a reverse proxy.
+      For example with `BASE_URL=/ansibleforms`, the application is served under `https://host/ansibleforms/`.
+      Note : when using an OAuth2 identity provider (Entra ID / OIDC), make sure the instance url in the provider settings includes the subpath, so the generated redirect uri matches.
   - name: DEFAULT_LANGUAGE
     type: string
     allowed: en, nl, fr, it, de, es

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,7 @@
 # default node variables
 PORT=8443
+# host the app under a url subpath, for example behind a reverse proxy
+# BASE_URL=/ansibleforms
 HTTPS=1
 LOG_CONSOLE_LEVEL=debug
 # enable https (set to 0 if you don't want https)

--- a/server/config/app.config.js
+++ b/server/config/app.config.js
@@ -2,12 +2,17 @@ import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
 import { existsSync } from "fs";
+import { normalizeBaseUrl } from "../src/lib/baseurl.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 var app_config = {
   port: process.env.PORT || 8000,
+  // host the app under a url subpath, for example behind a reverse proxy (issue #106)
+  // BASE_URL=/ansibleforms => app is served under https://host/ansibleforms/
+  // normalized to "" for root hosting, or "/subpath" (leading slash, no trailing slash)
+  baseUrl: normalizeBaseUrl(process.env.BASE_URL),
   nodeEnvironment: process.env.NODE_ENV || "production",
   showDesigner: (process.env.SHOW_DESIGNER ?? 1) == 1,
   allowSchemaCreation: (process.env.ALLOW_SCHEMA_CREATION ?? 1) == 1,

--- a/server/index.js
+++ b/server/index.js
@@ -1,12 +1,14 @@
 import express from 'express';
 import ansibleforms from './src/app.js';
 import appConfig from './config/app.config.js';
+import { injectBaseUrl } from './src/lib/baseurl.js';
 import { resolve } from 'path';
 import history from 'connect-history-api-fallback';
 import httpsConfig from './config/https.config.js';
 import logger from './src/lib/logger.js';
 import https from 'https';
 import http from 'http';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -22,35 +24,65 @@ async function start(){
   const publicPath = resolve(__dirname, './views');
   const staticConf = { maxAge: '1y', etag: false };
 
-  // Middleware to set no-cache for index.html
+  // load the built index.html once and rewrite its base tag to the configured
+  // base url, so the app can be hosted under a subpath (issue #106)
+  var indexHtml = null;
+  const indexPath = path.join(publicPath, 'index.html');
+  if (fs.existsSync(indexPath)) {
+    indexHtml = injectBaseUrl(fs.readFileSync(indexPath, 'utf-8'), appConfig.baseUrl);
+  } else {
+    logger.warning(`No index.html found in ${publicPath}, did you build the client?`);
+  }
+  const serveIndex = (req, res) => {
+    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+    if (indexHtml) {
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.send(indexHtml);
+    } else {
+      res.sendFile(indexPath);
+    }
+  };
+
+  // allow browser history
+  app.use(`/`, history()); // this order is important, it must be before the static files middleware
+
+  // serve the (rewritten) index.html with no-cache
   app.use((req, res, next) => {
-    if (req.path === '/' || req.path.endsWith('index.html')) {
-      res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+    if (req.method === 'GET' && (req.path === '/' || req.path.endsWith('index.html'))) {
+      return serveIndex(req, res);
     }
     next();
   });
-
-  // allow browser history
-  app.use(`/`, history()); // this order is important, it must be before the static files middleware  
   app.use("/", express.static(publicPath, staticConf));
 
   // Catchall for unmatched routes (after static and API)
-  app.get(/(.*)/, (req, res) => {
-    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
-    res.sendFile(path.join(publicPath, 'index.html'));
-  });
+  app.get(/(.*)/, serveIndex);
+
+  // when a base url is set, mount the whole app under the subpath
+  var rootApp = app;
+  if (appConfig.baseUrl) {
+    rootApp = express();
+    // redirect the root and the subpath without trailing slash, for convenience
+    // note : the exact path check matters, express also matches the trailing slash variant
+    rootApp.get('/', (req, res) => res.redirect(`${appConfig.baseUrl}/`));
+    rootApp.get(appConfig.baseUrl, (req, res, next) => {
+      if (req.path !== appConfig.baseUrl) return next();
+      res.redirect(`${appConfig.baseUrl}/${req.originalUrl.slice(req.path.length)}`);
+    });
+    rootApp.use(appConfig.baseUrl, app);
+  }
 
   // choose whether to start https or http server
   let httpServer;
   logger.notice(`Serving static files from ${publicPath}`);
-  logger.notice(`Exposing app under /`);
+  logger.notice(`Exposing app under ${appConfig.baseUrl || '/'}`);
   if (httpsConfig.https) {
     logger.notice("Running https !");
     const credentials = { key: httpsConfig.httpsKey, cert: httpsConfig.httpsCert };
-    httpServer = https.createServer(credentials, app);
+    httpServer = https.createServer(credentials, rootApp);
   } else {
     logger.notice("Running http !");
-    httpServer = http.createServer(app);
+    httpServer = http.createServer(rootApp);
   }
 
   // start the webserver and listen on the port we choose

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "dev": "NODE_ENV=development nodemon --watch src --watch schema --watch config ./index.js",
     "prod": "NODE_ENV=production npm-run-all build server",
     "copyviews": "mkdir -p ./dist/views && cp -R ../client/dist/* ./dist/views/",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@outlinewiki/passport-azure-ad-oauth2": "~0.1.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -139,18 +139,19 @@ const load = async (app) => {
   const authobj = passport.authenticate("jwt", { session: false });
 
   // api docs for v1 and v2
+  // note : the swagger paths must include the base url (subpath hosting, issue #106)
   const swaggerOptions = {
     customSiteTitle: "Ansibleforms Swagger UI",
-    customfavIcon: `/favicon.svg`,
-    customCssUrl: `/assets/css/swagger.css`,
+    customfavIcon: `${appConfig.baseUrl}/favicon.svg`,
+    customCssUrl: `${appConfig.baseUrl}/assets/css/swagger.css`,
     docExpansion: "none",
   };
   // v1 docs
-  swaggerDocumentV1.basePath = `/api/v1`;
+  swaggerDocumentV1.basePath = `${appConfig.baseUrl}/api/v1`;
   app.use(`/api/v1/docs`, cors(), swaggerUi.serveFiles(swaggerDocumentV1, swaggerOptions), swaggerUi.setup(swaggerDocumentV1, swaggerOptions));
-  
+
   // v2 docs
-  swaggerDocumentV2.basePath = `/api/v2`;
+  swaggerDocumentV2.basePath = `${appConfig.baseUrl}/api/v2`;
   app.use(`/api/v2/docs`, cors(), swaggerUi.serveFiles(swaggerDocumentV2, swaggerOptions), swaggerUi.setup(swaggerDocumentV2, swaggerOptions));
 
   // ========== V1 API Routes (DEPRECATED) ==========

--- a/server/src/controllers/v1/login.controller.js
+++ b/server/src/controllers/v1/login.controller.js
@@ -6,6 +6,7 @@ import Token from "../../models/token.model.js";
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
 import authConfig from '../../../config/auth.config.js';
+import appConfig from '../../../config/app.config.js';
 import logger from "../../lib/logger.js";
 import helpers from '../../lib/common.js';
 import RestResult from "../../models/restResult.model.js";
@@ -199,7 +200,7 @@ const logout = async function(req, res, next){
 
 // catches middleware error (non implemented strategy for example)
 const errorHandler = async function(err,req, res,next) {
-  res.redirect(`/login?error=${err}`)
+  res.redirect(`${appConfig.baseUrl}/login?error=${err}`)
 };
 
 /**
@@ -236,7 +237,7 @@ const authCallback = function(req, res, next, type) {
         logger.error(helpers.getError(err))
         return next(err)
       }else{
-        res.redirect(`/login?token=${token}`)
+        res.redirect(`${appConfig.baseUrl}/login?token=${token}`)
       }
 
     } catch (err) {

--- a/server/src/controllers/v2/login.controller.js
+++ b/server/src/controllers/v2/login.controller.js
@@ -6,6 +6,7 @@ import OIDC from "../../models/oidc.model.js";
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
 import authConfig from '../../../config/auth.config.js';
+import appConfig from '../../../config/app.config.js';
 import logger from "../../lib/logger.js";
 import helpers from '../../lib/common.js';
 import RestResult from "../../models/restResult.model.v2.js";
@@ -195,7 +196,7 @@ const logout = async function(req, res, next){
 
 // catches middleware error (non implemented strategy for example)
 const errorHandler = async function(err,req, res,next) {
-  res.redirect(`/login?error=${err}`)
+  res.redirect(`${appConfig.baseUrl}/login?error=${err}`)
 };
 
 /**
@@ -232,7 +233,7 @@ const authCallback = function(req, res, next, type) {
         logger.error(helpers.getError(err))
         return next(err)
       }else{
-        res.redirect(`/login?token=${token}`)
+        res.redirect(`${appConfig.baseUrl}/login?token=${token}`)
       }
 
     } catch (err) {

--- a/server/src/lib/baseurl.js
+++ b/server/src/lib/baseurl.js
@@ -1,0 +1,24 @@
+// helpers to host the application under a url subpath (issue #106)
+// the subpath comes from the BASE_URL environment variable, e.g. "/ansibleforms"
+
+// normalize a base url to "" (root hosting) or "/subpath" (leading slash, no trailing slash)
+export function normalizeBaseUrl(baseUrl) {
+  if (!baseUrl) return "";
+  var result = baseUrl.trim();
+  // strip surrounding slashes and collapse to a clean path
+  result = result.replace(/^\/+|\/+$/g, "");
+  if (!result) return "";
+  return "/" + result;
+}
+
+// rewrite the base tag in the built index.html to the configured base url,
+// so all relative asset/api references resolve under the subpath at runtime
+export function injectBaseUrl(html, baseUrl) {
+  if (!html) return html;
+  const href = `${baseUrl}/`;
+  if (/<base\s+href="[^"]*"\s*\/?>/.test(html)) {
+    return html.replace(/<base\s+href="[^"]*"\s*\/?>/, `<base href="${href}" />`);
+  }
+  // no base tag in the build (older build), insert one right after <head>
+  return html.replace(/<head>/, `<head>\n  <base href="${href}" />`);
+}

--- a/server/tests/base-url.test.mjs
+++ b/server/tests/base-url.test.mjs
@@ -1,0 +1,47 @@
+// tests for the subpath hosting helpers (issue #106) ; run with `npm test` (node --test)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeBaseUrl, injectBaseUrl } from "../src/lib/baseurl.js";
+
+test("normalizeBaseUrl", () => {
+  // root hosting
+  assert.equal(normalizeBaseUrl(undefined), "");
+  assert.equal(normalizeBaseUrl(""), "");
+  assert.equal(normalizeBaseUrl("/"), "");
+  assert.equal(normalizeBaseUrl(" / "), "");
+  // subpath hosting, any slash style is accepted
+  assert.equal(normalizeBaseUrl("/ansibleforms"), "/ansibleforms");
+  assert.equal(normalizeBaseUrl("ansibleforms"), "/ansibleforms");
+  assert.equal(normalizeBaseUrl("/ansibleforms/"), "/ansibleforms");
+  assert.equal(normalizeBaseUrl("ansibleforms/"), "/ansibleforms");
+  // nested subpath
+  assert.equal(normalizeBaseUrl("/apps/ansibleforms/"), "/apps/ansibleforms");
+});
+
+const INDEX_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <base href="/" />
+  <link rel="icon" href="favicon.svg" />
+</head>
+<body></body>
+</html>`;
+
+test("injectBaseUrl rewrites the base tag", () => {
+  const html = injectBaseUrl(INDEX_HTML, "/ansibleforms");
+  assert.match(html, /<base href="\/ansibleforms\/" \/>/);
+  assert.equal(html.match(/<base /g).length, 1);
+  // root hosting keeps a plain base tag
+  const rootHtml = injectBaseUrl(INDEX_HTML, "");
+  assert.match(rootHtml, /<base href="\/" \/>/);
+});
+
+test("injectBaseUrl inserts a base tag when missing (older build)", () => {
+  const html = injectBaseUrl("<html><head><link rel=\"icon\" href=\"favicon.svg\" /></head></html>", "/ansibleforms");
+  assert.match(html, /<head>\s*<base href="\/ansibleforms\/" \/>/);
+});
+
+test("injectBaseUrl handles empty input", () => {
+  assert.equal(injectBaseUrl(null, "/x"), null);
+  assert.equal(injectBaseUrl("", "/x"), "");
+});


### PR DESCRIPTION
## Summary

Fixes #106 — run AnsibleForms behind a reverse proxy, served from a subpath instead of the webroot:

```
BASE_URL=/ansibleforms   =>   https://host/ansibleforms/
```

A **single build / docker image works for any subpath** — the base path is applied at runtime, no rebuild needed. With no `BASE_URL` set, behavior is identical to today (root hosting).

## How it works

The earlier beta attempt (2023) showed the backend was easy but the frontend build had hardcoded absolute paths. This PR solves the frontend part the way you suggested back then ("convert it to dynamic code on the server side"), but with a single, tiny rewrite point:

1. The client is now built with vite's **relative base** (`base: './'` — note: the previous `build.base` option was silently ignored, vite's `base` is top-level). All bundled assets (js, css, fonts, dynamic chunks) become relative.
2. `index.html` now carries a `<base href="/" />` tag. At startup the server rewrites **only that tag** to the configured `BASE_URL` before serving it. Every relative asset reference then resolves under the subpath, at any route depth (history mode deep links included).
3. At runtime the client derives the base path from the base tag (`document.baseURI`) and uses it as:
   - `axios.defaults.baseURL` — one line that prefixes **all** existing `/api/v2/...` calls, no changes to the 100+ call sites
   - the `vue-router` history base
   - the OAuth2 full-page redirects on the login page
4. The server mounts the whole express app (gui, REST API, swagger) under the subpath; `/` and `/ansibleforms` (no trailing slash) conveniently redirect to `/ansibleforms/`. Swagger's `basePath`/favicon/css and the oauth2 `/login?token=...` redirects include the base url.

Remaining absolute references were cleaned up: navbar logos, login/logout/change-password background images (set from `index.html`, because relative `url()` inside CSS custom properties resolves inconsistently across browsers), api-docs links, and the error page's absolute `<a>` links (now router-links).

> Note for OAuth2 (Entra ID / OIDC): the redirect URI is generated from the instance url in the provider settings — make sure it includes the subpath (e.g. `https://host/ansibleforms`). This is documented with the new variable.

## Docs & tests

- `BASE_URL` documented in `help.yaml` (environment variables page) and `.env.example`
- Unit tests for the base url helpers — `npm test` in `server/` (plain `node:test`, no new dependencies)

## Verification

Tested end-to-end with the real client build served under `/myforms`:

- `GET /` → 302 `/myforms/`, `GET /myforms` → 302 `/myforms/` (query preserved), no redirect loops
- deep link `GET /myforms/jobs/5` serves the rewritten index (history fallback)
- headless-browser run: app boots, router lands on `/myforms/login`, **all** network requests (assets + api) are under `/myforms/` (`/myforms/api/v2/schema`, `/myforms/api/v2/auth/settings`, ...), login page renders fully including the theme background image
- regression run without `BASE_URL`: identical root-hosting behavior, base tag stays `/`
- client builds cleanly with `vite build`