### PR TITLE
Guard the forms-repo write lock against a status wedge

### DIFF
--- a/server/src/models/repository.model.js
+++ b/server/src/models/repository.model.js
@@ -473,12 +473,19 @@ class Repository extends CrudModel {
     if (!claim.affectedRows) {
       throw new Error(`Repository '${name}' is busy (a pull or sync is running), try again`)
     }
-    return rows[0].status ?? null
+    // never carry 'running' forward as the prior status : the SELECT and the
+    // claim are separate statements, so the SELECT could briefly catch another
+    // op's claim that was released before ours succeeded ; restoring 'running'
+    // would wedge the repo. Fall back to null (cleared) in that case.
+    const prior = rows[0].status
+    return (prior && prior !== 'running') ? prior : null
   }
 
-  // release a write claim taken by claimForWrite, restoring the prior status
+  // release a write claim taken by claimForWrite, restoring the prior status ;
+  // guarded on status='running' so it only ever clears OUR own claim and never
+  // overwrites a status another operation legitimately set afterwards
   static async releaseWrite(name, priorStatus) {
-    await mysql.do("update AnsibleForms.`repositories` set status = ? where name = ?", [priorStatus ?? null, name])
+    await mysql.do("update AnsibleForms.`repositories` set status = ? where name = ? and status = 'running'", [priorStatus ?? null, name])
   }
 
   // clear any repository left at status='running' by a process that died mid


### PR DESCRIPTION
Follow-up to #458 (forms repositories read+write). That PR serializes every git / working-tree operation through the `repositories.status` column, where `status='running'` is the lock. This hardens two helpers on that lock so a designer Save can never leave a repository wedged.

## The problem

`Repository.claimForWrite` captured the prior status with a `SELECT` separate from the claiming `UPDATE`:

```js
const rows = await mysql.do("SELECT status ... WHERE name = ?", [name])      // read prior
const claim = await mysql.do("update ... set status='running' where name=? and COALESCE(status,'')<>'running'", [name])
...
return rows[0].status ?? null                                                 // prior to restore on release
```

If that `SELECT` briefly caught another operation's transient `status='running'` (a pull/sync that was released just before our own claim succeeded), the value `'running'` was carried forward, and `releaseWrite` then restored it - leaving the repository stuck at `'running'`. Because the atomic claim requires `status<>'running'`, the repository would refuse every further pull/sync/save until the next restart cleared it.

The window is tiny (two sequential statements) and the wedge self-heals on restart via `resetStaleLocks`, so this is low severity - but it is a genuine "stuck repository" hazard worth closing.

## The fix

- `claimForWrite` never carries `'running'` forward as the prior status; it falls back to `null` (cleared) in that case. The durable statuses (`success` / `failed` / `null`) are still restored as before.
- `releaseWrite` is guarded on `status='running'`, so it only ever clears our own claim and never overwrites a status another operation legitimately set afterwards.

```diff
-    return rows[0].status ?? null
+    const prior = rows[0].status
+    return (prior && prior !== 'running') ? prior : null
...
-    await mysql.do("update ... set status = ? where name = ?", [priorStatus ?? null, name])
+    await mysql.do("update ... set status = ? where name = ? and status = 'running'", [priorStatus ?? null, name])
```

## Testing

- Server unit suite passes (22/22); no test changes needed (the lock helpers are exercised by the existing forms-git tests).
- Verified against a live database: a normal claim captures and restores the prior status exactly; a claim that observes a transient `running` never carries it forward; and a stray `releaseWrite` while not holding the lock is a no-op.
- Behaviour is unchanged in the common path and in non-repository (local forms) mode, where no claim is taken at all.
