### PR TITLE
Use localhost and env var for Vite dev proxy target

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "ansible-forms",
   "description": "The Vue3 front of the ansible forms web application",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite --host 127.0.0.1",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix --ignore-path .gitignore"

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -74,7 +74,7 @@ export default defineConfig({
     port: 8443,
     proxy: {
       '/api/': {
-        target: 'http://172.16.50.4:3001',
+        target: process.env.API_PROXY_TARGET || 'http://localhost:3001',
         changeOrigin: true,
         secure: false,
       }


### PR DESCRIPTION
## Summary

- Replace hardcoded `http://172.16.50.4:3001` proxy target with `process.env.API_PROXY_TARGET || 'http://localhost:3001'` — works out of the box for everyone; developers on different networks set the env var instead of editing the config
- Bind the dev server to `127.0.0.1` explicitly instead of `--host` (dual-stack) — fixes WSL2 localhost forwarding without exposing the dev server on the network

## Test plan

- [x] `npm run dev` in `client/` proxies API calls to `localhost:3001` by default
- [x] Setting `API_PROXY_TARGET=http://172.16.50.4:3001 npm run dev` proxies to the custom target
- [x] Dev server is accessible at `https://localhost:8443` from Windows (WSL2)