### PR TITLE
fix: remove dead server build scripts and deps

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,27 +5,16 @@
 npm install
 ```
 ## Start in production from the CLI
-This will run the server code in production environment.  
-**Make sure you build the client app first** !  See the main readme
-Make sure all environment variables are set or this will fail.
+This will run the server code in production environment.
+Make sure you build the client app first (see the main readme)
+and that all environment variables are set.
 ```
 npm run start
 ```
 ## Start in development from the CLI
-This will run the server code in development environment.  
-**Make sure you build the client app first** !  See the main readme
-Make sure all environment variables are set or this will fail.
+This will run the server code in development environment.
+Make sure you build the client app first (see the main readme)
+and that all environment variables are set.
 ```
 npm run dev
-```
-## Start in production with PM2 (prefered)
-This will run the server code in production environment with a decent process manager. (https://pm2.keymetrics.io/)
-**Make sure you build the client app first** !  See the main readme
-Make sure all environment variables are set or this will fail.
-```
-npm install -g pm2
-npm run build
-cp .env.example ./dist/.env.production
-cd dist
-pm2 start ecosystem.config.js --env production
 ```

--- a/server/package.json
+++ b/server/package.json
@@ -8,14 +8,8 @@
   },
   "description": "The nodejs backend for the ansible forms web applications",
   "scripts": {
-    "start": "npm run prod",
-    "build": "npm-run-all clean transpile",
-    "copy": "cp .env.development ./dist/.env.development",
-    "server": "NODE_ENV=development node ./",
+    "start": "NODE_ENV=production node ./",
     "dev": "NODE_ENV=development nodemon --watch src --watch schema --watch config ./index.js",
-    "prod": "NODE_ENV=production npm-run-all build server",
-    "copyviews": "mkdir -p ./dist/views && cp -R ../client/dist/* ./dist/views/",
-    "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -67,8 +61,6 @@
   "devDependencies": {
     "eslint": "~10.4.0",
     "nodemon": "~3.1.14",
-    "npm-run-all": "*",
-    "rimraf": "~6.1.3",
     "vitest": "^4.1.9"
   },
   "eslintConfig": {

--- a/server/tests/awx-workflow.test.mjs
+++ b/server/tests/awx-workflow.test.mjs
@@ -1,7 +1,7 @@
 // integration tests for the awx (workflow) job tracking ; run with `npm test` (node --test)
 // spins up a test awx api and mocks the database, then runs the real
 // Awx.trackJob / Awx.trackWorkflowJob polling loops against it (issue #420)
-import { test, before, after, beforeEach } from "node:test";
+const { test, beforeAll: before, afterAll: after, beforeEach } = await import("vitest");
 import assert from "node:assert/strict";
 import http from "http";
 

--- a/server/tests/base-url.test.mjs
+++ b/server/tests/base-url.test.mjs
@@ -1,5 +1,5 @@
 // tests for the subpath hosting helpers (issue #106) ; run with `npm test` (node --test)
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 import { normalizeBaseUrl, injectBaseUrl } from "../src/lib/baseurl.js";
 

--- a/server/tests/format-output.test.mjs
+++ b/server/tests/format-output.test.mjs
@@ -1,7 +1,7 @@
 // tests for Helpers.formatOutput ; run with `npm test` (node --test)
 // covers the classic ansible output coloring (regression) and the
 // awx workflow status lines coloring (issue #420)
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 
 // minimal env so the config modules load without a real setup

--- a/server/tests/forms-git.test.mjs
+++ b/server/tests/forms-git.test.mjs
@@ -1,7 +1,7 @@
 // tests for the forms <-> git pure helpers (issue #414) ; run with `npm test`
 // (node --test). Covers the pull-error mapping, config-repo resolution and the
 // per-file save-target placement (incl. staging of new forms).
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 import path from "path";
 import { friendlyPullError, configRepoFromPath, resolveTargetDir, claimAllOrRollback } from "../src/lib/forms-git.js";

--- a/server/tests/imagetype.test.mjs
+++ b/server/tests/imagetype.test.mjs
@@ -1,5 +1,5 @@
 // tests for the logo image magic-byte sniffer ; run with `npm test` (node --test)
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 import { sniffImageMime } from "../src/lib/imagetype.js";
 


### PR DESCRIPTION
## Summary

- Removed 6 dead npm scripts (`build`, `prod`, `clean`, `copy`, `copyviews`, `server`) that date from the old Babel transpile workflow. The server runs ESM directly now and the Dockerfile already does `node ./index.js` without a build step.
- Removed `npm-run-all` and `rimraf` dev dependencies (only used by those dead scripts).
- Simplified `start` script to `NODE_ENV=production node ./` instead of the broken `npm run prod` chain.
- Removed the outdated PM2 section from the README (it referenced the old `dist/` build output that no longer exists).

## Test plan

- [x] `npm run dev` still starts the server in development mode
- [x] `npm run start` starts the server in production mode
- [x] `npm test` still runs vitest
- [x] Docker build still works (it never used these scripts for the server)