### PR TITLE
fix: make .mjs tests vitest-compatible and fix AWX test failures

### DIFF
--- a/server/tests/__mocks__/app.config.js
+++ b/server/tests/__mocks__/app.config.js
@@ -3,4 +3,5 @@ export default {
   gitCloneCommand: 'git clone',
   gitPullCommand: 'git pull',
   filterJobOutputRegex: '.*',
+  awxApiPrefix: '/api/v2',
 };

--- a/server/tests/awx-workflow.test.mjs
+++ b/server/tests/awx-workflow.test.mjs
@@ -1,7 +1,7 @@
 // integration tests for the awx (workflow) job tracking ; run with `npm test` (node --test)
 // spins up a test awx api and mocks the database, then runs the real
 // Awx.trackJob / Awx.trackWorkflowJob polling loops against it (issue #420)
-import { test, before, after, beforeEach } from "node:test";
+const { test, beforeAll: before, afterAll: after, beforeEach } = await import("vitest");
 import assert from "node:assert/strict";
 import http from "http";
 

--- a/server/tests/base-url.test.mjs
+++ b/server/tests/base-url.test.mjs
@@ -1,5 +1,5 @@
 // tests for the subpath hosting helpers (issue #106) ; run with `npm test` (node --test)
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 import { normalizeBaseUrl, injectBaseUrl } from "../src/lib/baseurl.js";
 

--- a/server/tests/format-output.test.mjs
+++ b/server/tests/format-output.test.mjs
@@ -1,7 +1,7 @@
 // tests for Helpers.formatOutput ; run with `npm test` (node --test)
 // covers the classic ansible output coloring (regression) and the
 // awx workflow status lines coloring (issue #420)
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 
 // minimal env so the config modules load without a real setup

--- a/server/tests/forms-git.test.mjs
+++ b/server/tests/forms-git.test.mjs
@@ -1,7 +1,7 @@
 // tests for the forms <-> git pure helpers (issue #414) ; run with `npm test`
 // (node --test). Covers the pull-error mapping, config-repo resolution and the
 // per-file save-target placement (incl. staging of new forms).
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 import path from "path";
 import { friendlyPullError, configRepoFromPath, resolveTargetDir, claimAllOrRollback } from "../src/lib/forms-git.js";

--- a/server/tests/imagetype.test.mjs
+++ b/server/tests/imagetype.test.mjs
@@ -1,5 +1,5 @@
 // tests for the logo image magic-byte sniffer ; run with `npm test` (node --test)
-import { test } from "node:test";
+const { test } = await import("vitest");
 import assert from "node:assert/strict";
 import { sniffImageMime } from "../src/lib/imagetype.js";
 


### PR DESCRIPTION
## Summary

- The 5 `.mjs` test files imported `test`/`before`/`after` from `node:test`, which shadowed vitest's globals and caused vitest to report "No test suite found" for each file. Switched to importing from vitest so all suites are discovered and run.
- The 2 AWX test failures (`aborting a workflow job` and `abortJob hits the jobs endpoint`) were caused by the test mock config (`tests/__mocks__/app.config.js`) missing the `awxApiPrefix` property. `Awx.abortJob` builds the cancel URL as `uri + awxApiPrefix + jobsPath`, and without the prefix it produced an invalid URL. Adding `awxApiPrefix: '/api/v2'` to the mock fixes both.

Before: 5 suites failed (not found), 202 tests passed, 2 hidden failures.
After: 10 suites pass, 219 tests pass.

## Test plan

- [x] `npx vitest run` -- 10 files, 219 tests, all green