### PR TITLE
fix: password validation checks its own dirty state

### DIFF
--- a/client/src/pages/login.vue
+++ b/client/src/pages/login.vue
@@ -206,7 +206,7 @@ onMounted(() => {
          <BsInput v-model="user.username" @keyup_enter="login()" label="Username" placeholder="Username" icon="user"
             :hasError="$v.user.username.$invalid && $v.user.username.$dirty" :errors="$v.user.username.$errors" />
          <BsInput v-model="user.password" @keyup_enter="login()" type="password" label="Password" placeholder="Password" icon="lock"
-            :hasError="$v.user.password.$invalid && $v.user.username.$dirty" :errors="$v.user.password.$errors" />
+            :hasError="$v.user.password.$invalid && $v.user.password.$dirty" :errors="$v.user.password.$errors" />
          <button class="btn btn-primary w-100 py-2" @click="login()">Sign in</button>
          <div role="button" class="m-2 azure d-inline-block">
             <FaIcon icon="fac,azure" size="3x" @click="authAzureAd()" v-if="azureAdEnabled" />


### PR DESCRIPTION
## Summary

- The password field's error display was checking `$v.user.username.$dirty` instead of `$v.user.password.$dirty`. This meant password validation errors (e.g. "required") only appeared after the user interacted with the username field, not the password field.
- One-character fix in `login.vue:209`.

## Test plan

- [ ] Go to the login page
- [ ] Click directly into the password field, type something, then clear it
- [ ] Verify the "required" error appears on the password field
- [ ] Verify the username field still shows its own validation independently