### PR TITLE
fix: redirect to home when router guards deny access

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -38,49 +38,44 @@ import backups from "@/pages/admin/backups.vue"
 
 import TokenStorage from '@/lib/TokenStorage.js'
 
-// checkDesigner
 const checkDesigner=(to, from, next) => {
   var payload = TokenStorage.getPayload()
   if(payload?.user?.options?.showDesigner){
     next()
   }else{
-    console.log("You don't have access to the designer")
+    next({ name: "/" })
   }
 }
-// checkLogs
 const checkLogs=(to, from, next) => {
   var payload = TokenStorage.getPayload()
   if(payload?.user?.options?.showLogs){
     next()
   }else{
-    console.log("You don't have access to the logs")
+    next({ name: "/" })
   }
 }
-// checkJobs
 const checkJobs=(to, from, next) => {
   var payload = TokenStorage.getPayload()
   if(payload?.user?.options?.showJobs){
     next()
   }else{
-    console.log("You don't have access to the jobs")
+    next({ name: "/" })
   }
 }
-// checkSettings
 const checkSettings=(to, from, next) => {
   var payload = TokenStorage.getPayload()
   if(payload?.user?.options?.showSettings){
     next()
   }else{
-    console.log("You don't have access to the settings")
+    next({ name: "/" })
   }
 }
-// allowBackupOps
 const allowBackupOps=(to, from, next) => {
   var payload = TokenStorage.getPayload()
   if(payload?.user?.options?.allowBackupOps){
     next()
   }else{
-    console.log("You don't have access to the backups page")
+    next({ name: "/" })
   }
 }
 


### PR DESCRIPTION
## Summary

- The `beforeEnter` guards (`checkDesigner`, `checkLogs`, `checkJobs`, `checkSettings`, `allowBackupOps`) only called `next()` on success. On failure they logged to the console and returned nothing, which in Vue Router 4 leaves the navigation hanging -- the user sees a blank page with no feedback.
- All five guards now call `next({ name: "/" })` on failure, redirecting unauthorized users to the home page.

## Test plan

- [x] Log in as a user without designer access, navigate to `/designer` -- should redirect to home
- [x] Log in as a user without logs access, navigate to `/logs` -- should redirect to home
- [x] Log in as a user without jobs access, navigate to `/jobs` -- should redirect to home
- [x] Log in as a user without settings access, navigate to any `/admin/*` route -- should redirect to home
- [x] Log in as a user without backup ops, navigate to `/admin/backups` -- should redirect to home
- [x] Log in as admin (all access) -- all routes should still work normally