### PR TITLE
fix: remove unused jsonwebtoken from client dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,6 @@
     "dayjs": "^1.11.20",
     "dompurify": "^3.4.11",
     "highlight.js": "^11.11.1",
-    "jsonwebtoken": "^9.0.3",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.18.1",
     "roboto-fontface": "^0.10.0",


### PR DESCRIPTION
## Summary

- `jsonwebtoken` is a Node.js-only library (uses Node crypto, Buffer, etc.) that was listed in the client's `package.json` but never imported anywhere in `client/src/`. The client uses `jwt-decode` for token parsing instead.
- Removing it shrinks the client dependency tree and avoids pulling a server-side library into the frontend bundle.

## Test plan

- [ ] `npm install` in `client/` completes without errors
- [ ] `npm run build` succeeds
- [ ] Login flow still works (token decoding uses `jwt-decode`, not `jsonwebtoken`)