### PR TITLE
fix: add unhandledRejection handler and log via winston

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -14,6 +14,7 @@ import passport from "passport";
 
 // App configuration and utilities
 import Middleware from "./lib/middleware.js";
+import logger from "./lib/logger.js";
 import init from "./init/index.js";
 import appConfig from "../config/app.config.js";
 
@@ -131,8 +132,11 @@ const load = async (app) => {
   // mysql2 has a bug that can throw an uncaught exception if the mysql server crashes (not enough mem for example)
   // also git commands can chain child processes and cause issues
   process.on("uncaughtException", function (err) {
-    // handle the error safely
-    console.error("An uncaught exception happened, ignore... ", err);
+    logger.error("Uncaught exception: ", err);
+  });
+
+  process.on("unhandledRejection", function (reason) {
+    logger.error("Unhandled promise rejection: ", reason);
   });
 
   // using json web tokens as middleware


### PR DESCRIPTION
## Summary

- Added a `process.on('unhandledRejection')` handler. Without one, newer Node.js versions (v15+) crash the process on unhandled promise rejections. The handler logs the rejection via winston so it's visible in structured logs and log files.
- Switched the existing `uncaughtException` handler from `console.error` to the winston logger for consistency. Previously these events only appeared on stderr and were missing from the log files.

## Test plan

- [ ] Server starts normally (`npm run dev`)
- [ ] Errors still appear in the winston log output (check `server/persistent/logs/`)