### PR TITLE
Declarative config seed: define awx, credentials, oauth2, repositories, ldap and settings as code (CONFIG_SEED_PATH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Declarative config seed (config as code): set `CONFIG_SEED_PATH` to a yaml file declaring awx connections, credentials, oauth2 providers, repositories, ldap and settings, and AnsibleForms applies it at startup. Seeded objects are flagged `managed` and become read only for the API/UI, objects created by hand are never touched. Removing an object from the seed releases it; sections accept `prune: true` to delete instead. Secret values are referenced as `${ENV_VAR}` and resolved from the environment, so the file itself holds no secrets. An invalid seed (bad yaml, schema violation, unresolved variable) makes the server refuse to start. On a fresh database with a seed configured the schema is created automatically. See the new "Config seed" documentation page.
+
+### Fixed
+
+-   Deleting a repository whose clone never succeeded no longer fails on the missing directory.
+
 ## [6.2.1] - 2026-07-07
 
 ### Changed

--- a/docs/seed.md
+++ b/docs/seed.md
@@ -1,0 +1,132 @@
+---
+layout: default
+title: Config seed (config as code)
+nav_order: 5
+has_children: false
+---
+
+# Config seed (config as code)
+{: .no_toc }
+
+Declare your admin objects (AWX/AAP connections, credentials, oauth2 providers, repositories, ldap and settings) in a yaml file and let AnsibleForms apply it at startup. This closes the gap for teams that deploy AnsibleForms with GitOps tooling (ArgoCD, Flux, plain Helm) and want the whole instance defined in git, not clicked together in the UI.
+
+---
+
+## How it works
+
+Set the environment variable `CONFIG_SEED_PATH` to the path of a seed file (in Kubernetes typically a mounted ConfigMap). At startup AnsibleForms reads the file and upserts every object it declares.
+
+Objects that come from the seed are flagged **managed**:
+
+* they are enforced on every startup, so the seed file is the source of truth for them
+* the API (and therefore the UI) refuses to modify or delete them
+* anything created by hand in the UI is never touched by the seed
+
+Removing an object from the seed file only releases the managed flag, the record stays and becomes editable again. If you want removal to actually delete the record, set `prune: true` on that section.
+
+The seed file itself contains **no secrets**. Secret values are written as `${SOME_ENV_VAR}` and resolved from the environment at apply time, so you can feed them from Kubernetes Secrets (for example via external-secrets and a vault). For credentials you can also use `vault_path` and skip storing the secret in AnsibleForms entirely.
+
+A broken seed (invalid yaml, schema violation, a `${VAR}` that does not resolve) makes the server **refuse to start**. That is intentional: under a rolling update the previous pod keeps serving, so a typo can never take a running instance down, it only blocks the rollout of the bad configuration.
+
+Note: the seed file is not related to `config.yaml`, which holds the forms configuration (categories, roles, constants).
+
+## Sample seed file
+
+```yaml
+version: 1
+
+awx:
+  items:
+    - name: tower
+      uri: https://tower.example.com
+      token: ${SEED_AWX_TOKEN}
+      is_default: true
+
+repositories:
+  prune: true
+  items:
+    - name: forms
+      uri: https://git.example.com/ansibleforms-forms.git
+      branch: main
+      user: git
+      password: ${SEED_FORMS_REPO_TOKEN}
+      use_for_forms: true
+      use_for_config: true
+      rebase_on_start: true
+      cron: "*/30 * * * *"
+
+credentials:
+  items:
+    - name: vcenter
+      host: vcenter.example.com
+      user: svc_forms
+      password: ${SEED_VCENTER_PW}
+      is_database: false
+    - name: appdb
+      host: db.example.com
+      port: 3306
+      db_type: mysql
+      db_name: app
+      vault_path: secret/app/db   # user/password come from HashiCorp Vault at runtime
+
+oauth2:
+  items:
+    - name: EntraID
+      provider: azuread
+      client_id: ${SEED_AZURE_CLIENT_ID}
+      client_secret: ${SEED_AZURE_CLIENT_SECRET}
+      enable: true
+
+ldap:
+  server: ldap.example.com
+  port: 389
+  bind_user_dn: cn=bind,dc=example,dc=com
+  bind_user_pw: ${SEED_LDAP_BIND_PW}
+  search_base: dc=example,dc=com
+  username_attribute: uid
+  enable: true
+
+settings:
+  url: https://forms.example.com
+  mail_server: smtp.example.com
+  mail_port: 25
+  mail_from: forms@example.com
+```
+
+## Sections
+
+| Section | Type | Keyed by | Notes |
+|---|---|---|---|
+| `awx` | list | `name` | AWX/AAP/Ascender connections |
+| `credentials` | list | `name` | supports `vault_path` |
+| `oauth2` | list | `name` | oauth2/oidc providers |
+| `repositories` | list | `name` | git repositories, same fields as the UI |
+| `ldap` | object | single record | full ldap configuration |
+| `settings` | object | single record | mail settings and url only, forms config and logo are untouched |
+
+List sections accept `prune: true` to delete managed records that are no longer declared. The `ldap` and `settings` sections release their managed flag when removed from the file.
+
+Users and groups are deliberately out of scope: identity is usually external (ldap or oauth2) and the initial admin user is already covered by `ADMIN_USERNAME`/`ADMIN_PASSWORD`.
+
+## Kubernetes example
+
+Mount the seed as a ConfigMap and feed the secrets from a Kubernetes Secret:
+
+```yaml
+env:
+  - name: CONFIG_SEED_PATH
+    value: /app/dist/persistent/seed.yaml
+envFrom:
+  - secretRef:
+      name: ansibleforms-seed-secrets   # SEED_AWX_TOKEN, SEED_LDAP_BIND_PW, ...
+volumeMounts:
+  - name: seed
+    mountPath: /app/dist/persistent/seed.yaml
+    subPath: seed.yaml
+volumes:
+  - name: seed
+    configMap:
+      name: ansibleforms-seed
+```
+
+Rotating a secret means updating the Secret and restarting the pod (or redeploying), the seed re-applies on startup.

--- a/server/config/app.config.js
+++ b/server/config/app.config.js
@@ -17,6 +17,10 @@ var app_config = {
   showDesigner: (process.env.SHOW_DESIGNER ?? 1) == 1,
   allowSchemaCreation: (process.env.ALLOW_SCHEMA_CREATION ?? 1) == 1,
   configPath: process.env.CONFIG_PATH || path.resolve(__dirname + "/../persistent/config.yaml"),
+  // declarative config seed for admin objects (awx, credentials, oauth2,
+  // repositories, ldap, settings) ; empty = feature disabled. Not to be
+  // confused with configPath, which holds the forms configuration.
+  seedPath: process.env.CONFIG_SEED_PATH || "",
   formsFolderPath: process.env.FORMS_FOLDER_PATH || path.resolve(__dirname + "/../persistent/forms"),
   // staging area for new forms in repository mode : they live here until a
   // 'Push to repo' assigns them to a chosen repository (issue #414)

--- a/server/config/crud.config.js
+++ b/server/config/crud.config.js
@@ -13,7 +13,8 @@ const crudConfigs = {
       { name: 'password', isEncrypted: true, setDefault: true },
       { name: 'token', isEncrypted: true, setDefault: true },
       { name: 'ignore_certs', isBoolean: true },
-      { name: 'ca_bundle' }
+      { name: 'ca_bundle' },
+      { name: 'managed', isBoolean: true }
     ],
     allowCache: true,
     cacheTTL: 3600
@@ -36,7 +37,8 @@ const crudConfigs = {
       { name: 'auth_url' },
       { name: 'token_url' },
       { name: 'userinfo_url' },
-      { name: 'extra' }
+      { name: 'extra' },
+      { name: 'managed', isBoolean: true }
     ],
     allowCache: false
   },
@@ -54,7 +56,8 @@ const crudConfigs = {
       { name: 'is_database', isBoolean: true, setDefault: true },
       { name: 'description' },
       { name: 'db_type' },
-      { name: 'vault_path' }
+      { name: 'vault_path' },
+      { name: 'managed', isBoolean: true }
     ],
     allowCache: true,
     cacheTTL: 3600
@@ -129,7 +132,8 @@ const crudConfigs = {
       { name: 'cron' },
       { name: 'status' },
       { name: 'output' },
-      { name: 'head' }
+      { name: 'head' },
+      { name: 'managed', isBoolean: true }
     ],
     allowCache: true,
     cacheTTL: 3600
@@ -155,7 +159,8 @@ const crudConfigs = {
       { name: 'group_class' },
       { name: 'group_member_attribute' },
       { name: 'group_member_user_attribute' },
-      { name: 'mail_attribute' }
+      { name: 'mail_attribute' },
+      { name: 'managed', isBoolean: true }
     ],
     allowCache: false
   },

--- a/server/src/controllers/v1/settings.controller.js
+++ b/server/src/controllers/v1/settings.controller.js
@@ -35,10 +35,14 @@ const update = async function(req, res) {
         res.status(400).send({ error:true, message: 'Please provide all required fields' });
     }else{
         try {
+          const currentSettings = await Settings.find();
+          // settings coming from the config seed are read only for the API
+          if (currentSettings?.managed) {
+            return res.status(403).json(new RestResult("error","Settings are managed by the config seed and are read only",null,""));
+          }
           // If password is masked, preserve the existing password
           if (req.body.mail_password === '**********') {
-            const existingSettings = await Settings.find();
-            req.body.mail_password = existingSettings.mail_password;
+            req.body.mail_password = currentSettings.mail_password;
           }
           await Settings.update(new Settings(req.body));
           res.json(new RestResult("success","Settings updated",null,""));

--- a/server/src/controllers/v2/ldap.controller.js
+++ b/server/src/controllers/v2/ldap.controller.js
@@ -44,9 +44,13 @@ const update = async function(req, res) {
     return false;
   }
   try {
+    const existingLdap = await Ldap.find();
+    // an ldap config coming from the config seed is read only for the API
+    if (existingLdap?.managed) {
+      return res.status(403).json(RestResultv2.error(i18n.t(req, 'resources.failedUpdateLdap'), 'The ldap configuration is managed by the config seed and is read only'));
+    }
     // If password is masked, preserve the existing password
     if (req.body.bind_user_pw === '**********') {
-      const existingLdap = await Ldap.find();
       req.body.bind_user_pw = existingLdap.bind_user_pw;
     }
     await Ldap.update(new Ldap(req.body));

--- a/server/src/controllers/v2/settings.controller.js
+++ b/server/src/controllers/v2/settings.controller.js
@@ -39,10 +39,14 @@ const update = async function(req, res) {
         res.status(400).json(RestResult.error(i18n.t(req, 'errors.requiredFields')));
     }else{
         try {
+          const currentSettings = await Settings.find();
+          // settings coming from the config seed are read only for the API
+          if (currentSettings?.managed) {
+            return res.status(403).json(RestResult.error(i18n.t(req, 'resources.failedUpdateSettings'), 'Settings are managed by the config seed and are read only'));
+          }
           // If password is masked, preserve the existing password
           if (req.body.mail_password === '**********') {
-            const existingSettings = await Settings.find();
-            req.body.mail_password = existingSettings.mail_password;
+            req.body.mail_password = currentSettings.mail_password;
           }
           await Settings.update(new Settings(req.body));
           res.json(RestResult.single(null));

--- a/server/src/db/create_oauth2_providers_table.sql
+++ b/server/src/db/create_oauth2_providers_table.sql
@@ -16,5 +16,6 @@ CREATE TABLE `oauth2_providers` (
   `token_url` TEXT DEFAULT NULL,
   `userinfo_url` TEXT DEFAULT NULL,
   `extra` JSON DEFAULT NULL, -- for any additional provider-specific config
+  `managed` TINYINT(4) DEFAULT 0,
   UNIQUE KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/server/src/db/create_repositories_table.sql
+++ b/server/src/db/create_repositories_table.sql
@@ -14,6 +14,7 @@ CREATE TABLE `repositories` (
   `output` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `head` varchar(50) DEFAULT NULL,    
   `rebase_on_start` tinyint(4) DEFAULT NULL,  
+  `managed` tinyint(4) DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_AnsibleForms_repositories_natural_key` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/server/src/db/create_schema_and_tables.sql
+++ b/server/src/db/create_schema_and_tables.sql
@@ -48,6 +48,7 @@ CREATE TABLE `credentials` (
   `db_name` varchar(255) DEFAULT NULL,  
   `is_database` tinyint(4) DEFAULT 1,
   `vault_path` varchar(500) DEFAULT NULL,
+  `managed` tinyint(4) DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_AnsibleForms_credentials_natural_key` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -71,7 +72,8 @@ CREATE TABLE `ldap` (
   `group_member_user_attribute` varchar(250) DEFAULT NULL,
   `is_advanced` tinyint(4) DEFAULT NULL,
   `mail_attribute` varchar(250) DEFAULT NULL,
-  `enable` tinyint(4) DEFAULT NULL
+  `enable` tinyint(4) DEFAULT NULL,
+  `managed` tinyint(4) DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 -- create awx table
 DROP TABLE IF EXISTS `awx`;
@@ -87,6 +89,7 @@ CREATE TABLE `awx` (
   `use_credentials` tinyint(4) DEFAULT NULL,
   `ignore_certs` tinyint(4) DEFAULT NULL,
   `ca_bundle` text DEFAULT NULL,
+  `managed` tinyint(4) DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_AnsibleForms_awx_natural_key` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -137,7 +140,8 @@ CREATE TABLE `settings` (
   `mail_from` varchar(250) DEFAULT NULL,
   `url` varchar(250) DEFAULT NULL,
   `forms_yaml` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `logo` longtext DEFAULT NULL
+  `logo` longtext DEFAULT NULL,
+  `managed` tinyint(4) DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 -- oauth2 providers table
 USE `AnsibleForms`;
@@ -158,6 +162,7 @@ CREATE TABLE `oauth2_providers` (
   `token_url` TEXT DEFAULT NULL,
   `userinfo_url` TEXT DEFAULT NULL,
   `extra` JSON DEFAULT NULL, -- for any additional provider-specific config
+  `managed` TINYINT(4) DEFAULT 0,
   UNIQUE KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 -- create repositories table
@@ -176,6 +181,7 @@ CREATE TABLE `repositories` (
   `output` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `head` varchar(50) DEFAULT NULL,    
   `rebase_on_start` tinyint(4) DEFAULT NULL,  
+  `managed` tinyint(4) DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_AnsibleForms_repositories_natural_key` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/server/src/db/create_settings_table.sql
+++ b/server/src/db/create_settings_table.sql
@@ -8,6 +8,7 @@ CREATE TABLE `settings` (
   `mail_from` varchar(250) DEFAULT NULL,
   `url` varchar(250) DEFAULT NULL,
   `forms_yaml` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `logo` longtext DEFAULT NULL
+  `logo` longtext DEFAULT NULL,
+  `managed` tinyint(4) DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/server/src/init/index.js
+++ b/server/src/init/index.js
@@ -16,6 +16,7 @@ import appConfig from "../../config/app.config.js";
 import User from "../models/user.model.js";
 import Group from "../models/group.model.js";
 import Token from "../models/token.model.js";
+import { applyConfigSeed } from "../lib/seed.js";
 
 const init = async function(){
 
@@ -78,6 +79,20 @@ const init = async function(){
     }
     // Schema is missing - stop initialization here
     schemaIsReady = false
+  }
+
+  // With a config seed declared, a missing schema is created automatically
+  // (when ALLOW_SCHEMA_CREATION permits) : a declarative deployment must come
+  // up on a fresh database without a manual /schema call.
+  if(!schemaIsReady && appConfig.seedPath){
+    logger.notice("Config seed is set and the schema is not ready : creating the schema")
+    try{
+      await Schema.createTables()
+      const recheck = await Schema.hasSchema()
+      schemaIsReady = recheck.data.failed.length==0
+    }catch(err){
+      logger.error("Failed to create the schema for the config seed : " + (err.message || err))
+    }
   }
 
   // Only continue with group/user creation if schema is ready
@@ -168,6 +183,18 @@ const init = async function(){
   }
 
   logger.info("All database records are checked")
+
+  // declarative config seed (CONFIG_SEED_PATH) : apply before the cron and
+  // repository bootstrap below, so seeded repositories and crons take part in
+  // them. A broken seed is fatal on purpose : better to refuse to start than
+  // to run with a configuration that does not match what was declared (under
+  // a rolling update the previous pod keeps serving).
+  try {
+    await applyConfigSeed({ schemaIsReady })
+  } catch (err) {
+    logger.error("Config seed failed, refusing to start : " + (err.message || err))
+    process.exit(1)
+  }
 
   logger.info("Checking ssh keys")
   Ssh.generate(false)

--- a/server/src/lib/seed-schema.js
+++ b/server/src/lib/seed-schema.js
@@ -1,0 +1,199 @@
+// Declarative config seed : schema validation and environment interpolation.
+// Pure helpers with no database access, so they are unit testable.
+// The seed file itself never contains secrets : secret values are referenced
+// as ${SOME_ENV_VAR} and resolved from the process environment at apply time.
+import Ajv from "ajv";
+
+const str = { type: "string" };
+const bool = { type: "boolean" };
+// numeric fields may arrive as strings when they come from ${ENV} interpolation
+const strOrInt = { type: ["string", "integer"] };
+
+const awxItem = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "uri"],
+  properties: {
+    name: str,
+    description: str,
+    uri: str,
+    is_default: bool,
+    use_credentials: bool,
+    username: str,
+    password: str,
+    token: str,
+    ignore_certs: bool,
+    ca_bundle: str,
+  },
+};
+
+const credentialItem = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name"],
+  properties: {
+    name: str,
+    description: str,
+    user: str,
+    password: str,
+    host: str,
+    port: strOrInt,
+    db_name: str,
+    db_type: str,
+    secure: bool,
+    is_database: bool,
+    vault_path: str,
+  },
+};
+
+const oauth2Item = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "provider", "client_id", "client_secret"],
+  properties: {
+    name: str,
+    description: str,
+    provider: str,
+    issuer: str,
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    enable: bool,
+    groupfilter: str,
+    redirect_uri: str,
+    scope: str,
+    auth_url: str,
+    token_url: str,
+    userinfo_url: str,
+    extra: str,
+  },
+};
+
+const repositoryItem = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "uri"],
+  properties: {
+    name: str,
+    description: str,
+    uri: str,
+    branch: str,
+    user: str,
+    password: str,
+    use_for_config: bool,
+    use_for_forms: bool,
+    use_for_playbooks: bool,
+    use_for_vars_files: bool,
+    rebase_on_start: bool,
+    cron: str,
+  },
+};
+
+const listSection = (item) => ({
+  type: "object",
+  additionalProperties: false,
+  required: ["items"],
+  properties: {
+    prune: bool,
+    items: { type: "array", items: item },
+  },
+});
+
+const ldapSection = {
+  type: "object",
+  additionalProperties: false,
+  required: ["server", "port", "bind_user_dn", "bind_user_pw", "search_base", "username_attribute"],
+  properties: {
+    server: str,
+    port: strOrInt,
+    ignore_certs: bool,
+    enable_tls: bool,
+    cert: str,
+    ca_bundle: str,
+    bind_user_dn: str,
+    bind_user_pw: str,
+    search_base: str,
+    username_attribute: str,
+    groups_attribute: str,
+    enable: bool,
+    is_advanced: bool,
+    groups_search_base: str,
+    group_class: str,
+    group_member_attribute: str,
+    group_member_user_attribute: str,
+    mail_attribute: str,
+  },
+};
+
+const settingsSection = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    mail_server: str,
+    mail_port: strOrInt,
+    mail_secure: bool,
+    mail_username: str,
+    mail_password: str,
+    mail_from: str,
+    url: str,
+  },
+};
+
+export const seedSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    version: { type: "integer", enum: [1] },
+    awx: listSection(awxItem),
+    credentials: listSection(credentialItem),
+    oauth2: listSection(oauth2Item),
+    repositories: listSection(repositoryItem),
+    ldap: ldapSection,
+    settings: settingsSection,
+  },
+};
+
+const ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
+const validator = ajv.compile(seedSchema);
+
+// Validates the parsed seed document ; throws with all validation messages
+// combined so the operator sees everything wrong in one go.
+export function validateSeed(doc) {
+  if (!validator(doc)) {
+    const details = (validator.errors || [])
+      .map((e) => `${e.instancePath || "/"} ${e.message}`)
+      .join(" ; ");
+    throw new Error(`Seed file validation failed : ${details}`);
+  }
+  return true;
+}
+
+// Recursively replaces ${VAR} references in all string values with the
+// corresponding environment variable. Unknown variables are collected and
+// reported in a single error : a seed with unresolved secrets must not apply.
+export function interpolateEnv(value, env = process.env) {
+  const missing = new Set();
+  const walk = (v) => {
+    if (typeof v === "string") {
+      return v.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name) => {
+        if (env[name] === undefined) {
+          missing.add(name);
+          return match;
+        }
+        return env[name];
+      });
+    }
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === "object") {
+      const out = {};
+      for (const k of Object.keys(v)) out[k] = walk(v[k]);
+      return out;
+    }
+    return v;
+  };
+  const result = walk(value);
+  if (missing.size > 0) {
+    throw new Error(`Seed file references undefined environment variables : ${[...missing].sort().join(", ")}`);
+  }
+  return result;
+}

--- a/server/src/lib/seed.js
+++ b/server/src/lib/seed.js
@@ -1,0 +1,171 @@
+// Declarative config seed (config as code for the admin objects).
+//
+// When CONFIG_SEED_PATH is set, the file it points to is read at startup and
+// the admin objects it declares (awx, credentials, oauth2 providers,
+// repositories, ldap, settings) are upserted into the database. Objects that
+// come from the seed are flagged `managed` : they are enforced on every apply
+// and the API refuses manual changes to them, while anything created by hand
+// stays untouched. Removing an object from the seed releases the flag ;
+// deleting it too requires `prune: true` on the section.
+//
+// An invalid seed (bad yaml, schema violation, unresolved ${ENV} reference)
+// is fatal on purpose : the server refuses to start rather than run with a
+// configuration that does not match what the operator declared.
+import fs from "fs";
+import yaml from "yaml";
+import logger from "./logger.js";
+import crypto from "./crypto.js";
+import appConfig from "../../config/app.config.js";
+import { validateSeed, interpolateEnv } from "./seed-schema.js";
+import CrudModel from "../models/crud.model.js";
+import Awx from "../models/awx.model.js";
+import OAuth2 from "../models/oauth2.model.js";
+import Credential from "../models/credential.model.v2.js";
+import Repository from "../models/repository.model.js";
+import Ldap from "../models/ldap.model.js";
+import Settings from "../models/settings.model.js";
+import mysql from "../models/db.model.js";
+
+const seedOpts = { fromSeed: true };
+
+// The list sections all share the same upsert/release/prune mechanics ; only
+// the model calls differ (repositories are keyed by name in their model API).
+const listSections = [
+  {
+    key: "awx",
+    modelName: "awx",
+    create: (d) => Awx.create(d, seedOpts),
+    update: (d, row) => Awx.update(d, row.id, seedOpts),
+    remove: (row) => Awx.delete(row.id, seedOpts),
+  },
+  {
+    key: "credentials",
+    modelName: "credential",
+    defaults: { description: "" },
+    create: (d) => Credential.create(d, seedOpts),
+    update: (d, row) => Credential.update(d, row.id, seedOpts),
+    remove: (row) => Credential.delete(row.id, seedOpts),
+  },
+  {
+    key: "oauth2",
+    modelName: "oauth2",
+    create: (d) => OAuth2.create(d, seedOpts),
+    update: (d, row) => OAuth2.update(d, row.id, seedOpts),
+    remove: (row) => OAuth2.delete(row.id, seedOpts),
+  },
+  {
+    key: "repositories",
+    modelName: "repositories",
+    defaults: { description: "" },
+    create: (d) => Repository.create(d, seedOpts),
+    update: (d, row) => Repository.update(d, row.name, seedOpts),
+    remove: (row) => Repository.delete(row.name, seedOpts),
+  },
+];
+
+async function applyListSection(section, cfg, summary) {
+  const items = cfg.items || [];
+  const declared = new Set(items.map((i) => i.name));
+
+  for (const item of items) {
+    const data = { ...(section.defaults || {}), ...item, managed: true };
+    const existing = await CrudModel.findByName(section.modelName, item.name);
+    if (existing) {
+      await section.update(data, existing);
+      summary.updated++;
+    } else {
+      await section.create(data);
+      summary.created++;
+    }
+  }
+
+  // managed rows that are no longer declared : release them, or delete them
+  // when the section asks for pruning ; rows created by hand are never touched
+  const all = await CrudModel.findAll(section.modelName);
+  for (const row of all) {
+    if (row.managed && !declared.has(row.name)) {
+      if (cfg.prune) {
+        await section.remove(row);
+        summary.pruned++;
+      } else {
+        await CrudModel.update(section.modelName, { managed: false }, row.id, seedOpts);
+        summary.released++;
+      }
+    }
+  }
+}
+
+async function applyLdap(cfg) {
+  // the Ldap constructor handles boolean casts, password encryption and the
+  // advanced-mode field grooming, exactly like a save from the UI would
+  const record = { ...new Ldap(cfg) };
+  delete record.testuser;
+  delete record.testpassword;
+  for (const k of Object.keys(record)) {
+    if (record[k] === undefined) delete record[k];
+  }
+  record.managed = 1;
+  await Ldap.update(record);
+}
+
+async function applySettings(cfg) {
+  // partial update on purpose : the settings row also carries forms_yaml and
+  // the logo, which are not seed material and must survive untouched
+  const record = {};
+  for (const k of ["mail_server", "mail_port", "mail_username", "mail_from", "url"]) {
+    if (cfg[k] !== undefined) record[k] = cfg[k];
+  }
+  if (cfg.mail_secure !== undefined) record.mail_secure = cfg.mail_secure ? 1 : 0;
+  if (cfg.mail_password !== undefined) {
+    record.mail_password = cfg.mail_password === "" ? "" : crypto.encrypt(cfg.mail_password);
+  }
+  record.managed = 1;
+  await Settings.update(record);
+}
+
+// Applies the seed file if CONFIG_SEED_PATH is set. Returns a summary object,
+// or null when no seed is configured. Throws on any error : the caller treats
+// that as fatal.
+export async function applyConfigSeed({ schemaIsReady = true } = {}) {
+  const seedPath = appConfig.seedPath;
+  if (!seedPath) return null;
+
+  if (!schemaIsReady) {
+    throw new Error("CONFIG_SEED_PATH is set but the database schema is not ready");
+  }
+  if (!fs.existsSync(seedPath)) {
+    throw new Error(`CONFIG_SEED_PATH points to '${seedPath}' but the file does not exist`);
+  }
+
+  logger.notice(`Applying config seed from ${seedPath}`);
+  let doc = yaml.parse(fs.readFileSync(seedPath, "utf8"));
+  if (doc === null || doc === undefined) doc = {};
+  doc = interpolateEnv(doc);
+  validateSeed(doc);
+
+  const summary = { created: 0, updated: 0, released: 0, pruned: 0 };
+
+  for (const section of listSections) {
+    // an absent section behaves like an empty one : its managed rows are released
+    await applyListSection(section, doc[section.key] || { items: [] }, summary);
+  }
+
+  if (doc.ldap) {
+    await applyLdap(doc.ldap);
+  } else {
+    await mysql.do("UPDATE AnsibleForms.`ldap` SET managed=0 WHERE managed=1");
+  }
+
+  if (doc.settings) {
+    await applySettings(doc.settings);
+  } else {
+    await mysql.do("UPDATE AnsibleForms.`settings` SET managed=0 WHERE managed=1");
+  }
+
+  logger.notice(
+    `Config seed applied : ${summary.created} created, ${summary.updated} updated, ${summary.released} released, ${summary.pruned} pruned`
+  );
+  return summary;
+}
+
+export default { applyConfigSeed };

--- a/server/src/models/awx.model.js
+++ b/server/src/models/awx.model.js
@@ -30,16 +30,16 @@ class Awx extends CrudModel {
   }
 
   // Proxy CRUD methods to CrudModel, injecting custom preProcess
-  static async create(data) {
+  static async create(data, opts) {
     data = await this.preProcess(data, 'create');
-    return super.create(this.modelName, data);
+    return super.create(this.modelName, data, opts);
   }
-  static async update(data, id) {
+  static async update(data, id, opts) {
     data = await this.preProcess(data, 'update');
-    return super.update(this.modelName, data, id);
+    return super.update(this.modelName, data, id, opts);
   }
-  static async delete(id) {
-    return super.delete(this.modelName, id);
+  static async delete(id, opts) {
+    return super.delete(this.modelName, id, opts);
   }
   static async findById(id) {
     return super.findById(this.modelName, id);

--- a/server/src/models/credential.model.js
+++ b/server/src/models/credential.model.js
@@ -11,6 +11,15 @@ const cache = new NodeCache({
 });
 
 
+// credentials flagged `managed` come from the declarative config seed and
+// are read only for the API (the seed applies through the v2 model)
+async function assertNotManaged(id) {
+  const res = await mysql.do("SELECT managed FROM AnsibleForms.`credentials` WHERE id = ?", [id]);
+  if (res.length && res[0].managed) {
+    throw "This credential is managed by the config seed and is read only";
+  }
+}
+
 //credential object create
 class Credential {
   constructor(credential) {
@@ -37,12 +46,14 @@ class Credential {
   static async update(record, id) {
     const r = await Credential.findById(id); // quickly search name
     record.name = r[0].name;
+    await assertNotManaged(id);
     logger.info(`Updating credential ${record.name}`);
     var res = await mysql.do("UPDATE AnsibleForms.`credentials` set ? WHERE id=?", [record, id]);
     cache.del(record.name);
     return res;
   }
   static async delete(id) {
+    await assertNotManaged(id);
     logger.info(`Deleting credential ${id}`);
     var res = await mysql.do("DELETE FROM AnsibleForms.`credentials` WHERE id = ? AND name<>'admins'", [id]);
     return res;

--- a/server/src/models/credential.model.v2.js
+++ b/server/src/models/credential.model.v2.js
@@ -8,16 +8,16 @@ import { vaultRead, mapVaultPayloadToCredential } from '../lib/vault.js';
 class CredentialModel extends CrudModel {
   static modelName = 'credential';
 
-  static async create(data) {
-    return super.create(this.modelName, data);
+  static async create(data, opts) {
+    return super.create(this.modelName, data, opts);
   }
 
-  static async update(data, id) {
-    return super.update(this.modelName, data, id);
+  static async update(data, id, opts) {
+    return super.update(this.modelName, data, id, opts);
   }
 
-  static async delete(id) {
-    return super.delete(this.modelName, id);
+  static async delete(id, opts) {
+    return super.delete(this.modelName, id, opts);
   }
 
   static async findAll() {

--- a/server/src/models/crud.model.js
+++ b/server/src/models/crud.model.js
@@ -149,8 +149,21 @@ class CrudModel {
     return data;
   }
 
-  static async create(modelName, data) {
+  // Records flagged `managed` come from the declarative config seed and are
+  // read only for the API ; only the seed itself (opts.fromSeed) may touch them.
+  static async assertNotManaged(modelName, id) {
+    const config = this.getConfig(modelName);
+    if (!config.fields.some(f => f.name === 'managed')) return;
+    const key = config.fields.find(f => f.isKey)?.name || 'id';
+    const res = await mysql.do(`SELECT managed FROM ${config.table} WHERE ${key} = ?`, [id]);
+    if (res.length && res[0].managed) {
+      throw new Errors.AccessDeniedError(`This ${modelName} record is managed by the config seed and is read only`);
+    }
+  }
+
+  static async create(modelName, data, opts = {}) {
     // data = await this.preProcess(modelName, data, 'create');
+    if (!opts.fromSeed) delete data.managed; // the flag is owned by the seed
     const config = this.getConfig(modelName);
     // Check required fields
     for (const field of config.fields) {
@@ -165,12 +178,16 @@ class CrudModel {
     return res.insertId || null;
   }
 
-  static async update(modelName, data, id) {
+  static async update(modelName, data, id, opts = {}) {
     // data = await this.preProcess(modelName, data, 'update');
     const config = this.getConfig(modelName);
     const cache = this.getCache(modelName);
     const key = config.fields.find(f => f.isKey)?.name || 'id';
     await this.checkExist(modelName, id);
+    if (!opts.fromSeed) {
+      delete data.managed; // the flag is owned by the seed
+      await this.assertNotManaged(modelName, id);
+    }
     const fieldValues = this.getFieldValues(modelName, data, true);
     const sql = `UPDATE ${config.table} SET ? WHERE ${key} = ?`;
     const res = await mysql.do(sql, [fieldValues, id]);
@@ -182,11 +199,12 @@ class CrudModel {
     return res.affectedRows > 0;
   }
 
-  static async delete(modelName, id) {
+  static async delete(modelName, id, opts = {}) {
     const config = this.getConfig(modelName);
     const cache = this.getCache(modelName);
     const key = config.fields.find(f => f.isKey)?.name || 'id';
     await this.checkExist(modelName, id);
+    if (!opts.fromSeed) await this.assertNotManaged(modelName, id);
     // Get the record first to get the name for cache removal
     let record = null;
     if (config.allowCache && cache) {

--- a/server/src/models/oauth2.model.js
+++ b/server/src/models/oauth2.model.js
@@ -14,16 +14,16 @@ class OAuth2 extends CrudModel {
         }
         return data;
     }
-    static async create(data) {
+    static async create(data, opts) {
         data =await this.preProcess(data, 'create');
-        return super.create(this.modelName, data);
+        return super.create(this.modelName, data, opts);
     }
-    static async update(data, id) {
+    static async update(data, id, opts) {
         data = await this.preProcess(data, 'update');
-        return super.update(this.modelName, data, id);
+        return super.update(this.modelName, data, id, opts);
     }
-    static async delete(id) {
-        return super.delete(this.modelName, id);
+    static async delete(id, opts) {
+        return super.delete(this.modelName, id, opts);
     }
     static async findById(id) {
         return super.findById(this.modelName, id);

--- a/server/src/models/repo.model.js
+++ b/server/src/models/repo.model.js
@@ -67,8 +67,8 @@ Repo.delete = async function (name) {
     logger.notice("Deleting repository " + name)
     var directory = config.repoPath
 
-    fs.accessSync(path.join(directory,name))
-    // if found and access continue with delete
+    // a repository whose clone never succeeded has no directory on disk ;
+    // deleting it must not fail on that (rmSync with force is a no-op then)
     fs.rmSync(path.join(directory,name),{force:true,recursive:true})
     return
 

--- a/server/src/models/repository.model.js
+++ b/server/src/models/repository.model.js
@@ -14,15 +14,15 @@ class Repository extends CrudModel {
   static modelName = 'repositories';
 
   // Override create to trigger clone after creation
-  static async create(data) {
+  static async create(data, opts) {
     logger.info(`Creating repository ${data.name}`);
-    const insertId = await super.create(this.modelName, data);
+    const insertId = await super.create(this.modelName, data, opts);
     Repository.clone(data.name); // Don't await - clone happens in background
     return insertId;
   }
 
   // Override update to handle password properly
-  static async update(data, name) {
+  static async update(data, name, opts) {
     logger.info(`Updating repository ${name}`);
     // Get current record to find id
     const repo = await this.findByName(name);
@@ -31,14 +31,16 @@ class Repository extends CrudModel {
     // Remove empty fields
     helpers.removeEmptyFields(data);
     
-    return super.update(this.modelName, data, repo.id);
+    return super.update(this.modelName, data, repo.id, opts);
   }
 
   // Override delete to cleanup disk
-  static async delete(name) {
+  static async delete(name, opts) {
     logger.info(`Deleting repository ${name}`);
     const repo = await this.findByName(name);
     if (!repo) throw new Error(`No repository found with name ${name}`);
+    // seed-managed repositories are read only for the API (deletes included)
+    if (!opts?.fromSeed) await Repository.assertNotManaged(this.modelName, repo.id);
     
     Repo.delete(name);
     const res = await mysql.do("DELETE FROM AnsibleForms.`repositories` WHERE name = ?", [name]);

--- a/server/src/models/schema.model.js
+++ b/server/src/models/schema.model.js
@@ -57,26 +57,30 @@ class Schema {
     Schema._cachedOk = result;
     return result;
   }
-  static async create() {
-    logger.notice(`Trying to create database schema 'AnsibleForms' and tables`);
-    if (appConfig.allowSchemaCreation) {
-      // added in 5.0.3
-      const buffer = fs.readFileSync(`${__dirname}/../db/create_schema_and_tables.sql`);
-      const query = buffer.toString();
-      var res = await mysql.do(query);
-      if (res.length > 0) {
-        logger.notice(`Created schema 'AnsibleForms' and tables`);
-        await init()
-        // Invalidate so the next hasSchema() call re-runs the full check.
-        Schema._cachedOk = null;
-        return { message: `Created schema 'AnsibleForms' and tables` };
-      } else {
-        throw new Error(`Failed to create schema 'AnsibleForms' and/or tables`);
-      }
-    } else {
+  // Creates the schema and tables only, without re-running the app
+  // initialization ; used by create() below and by the startup config seed
+  // (a declarative deployment must come up without a manual /schema call).
+  static async createTables() {
+    if (!appConfig.allowSchemaCreation) {
       throw new Error(`Schema creation is disabled`);
     }
-    
+    // added in 5.0.3
+    const buffer = fs.readFileSync(`${__dirname}/../db/create_schema_and_tables.sql`);
+    const query = buffer.toString();
+    var res = await mysql.do(query);
+    if (!(res.length > 0)) {
+      throw new Error(`Failed to create schema 'AnsibleForms' and/or tables`);
+    }
+    logger.notice(`Created schema 'AnsibleForms' and tables`);
+    // Invalidate so the next hasSchema() call re-runs the full check.
+    Schema._cachedOk = null;
+  }
+
+  static async create() {
+    logger.notice(`Trying to create database schema 'AnsibleForms' and tables`);
+    await Schema.createTables();
+    await init()
+    return { message: `Created schema 'AnsibleForms' and tables` };
   }
 }
 
@@ -484,6 +488,15 @@ async function patchVersion6(messages, success, failed) {
   // This stores an optional custom logo as a base64 data url, shown in the
   // navbar instead of the default AnsibleForms logo (admin panel > logo)
   await checkPromise(addColumn("settings", "logo", "longtext", true, "NULL"), messages, success, failed);
+
+  // Add managed column (6.3.0) : records created by the declarative config
+  // seed (CONFIG_SEED_PATH) are flagged managed and become read only for the API
+  await checkPromise(addColumn("awx", "managed", "tinyint(4)", true, "0"), messages, success, failed);
+  await checkPromise(addColumn("credentials", "managed", "tinyint(4)", true, "0"), messages, success, failed);
+  await checkPromise(addColumn("oauth2_providers", "managed", "tinyint(4)", true, "0"), messages, success, failed);
+  await checkPromise(addColumn("repositories", "managed", "tinyint(4)", true, "0"), messages, success, failed);
+  await checkPromise(addColumn("ldap", "managed", "tinyint(4)", true, "0"), messages, success, failed);
+  await checkPromise(addColumn("settings", "managed", "tinyint(4)", true, "0"), messages, success, failed);
 }
 
 // PATCHING : Patch All

--- a/server/tests/config-seed.test.mjs
+++ b/server/tests/config-seed.test.mjs
@@ -1,0 +1,109 @@
+// tests for the declarative config seed helpers (schema validation and env
+// interpolation) ; the apply logic itself needs a database and is covered by
+// the integration flow, these cover the pure parts
+const { test } = await import("vitest");
+import assert from "node:assert/strict";
+import { validateSeed, interpolateEnv } from "../src/lib/seed-schema.js";
+
+const validSeed = {
+  version: 1,
+  awx: {
+    items: [
+      { name: "tower", uri: "https://tower.example.com", token: "abc", is_default: true },
+    ],
+  },
+  credentials: {
+    prune: true,
+    items: [
+      { name: "vcenter", host: "vcenter.example.com", user: "svc", password: "secret", is_database: false },
+      { name: "vaulted", host: "db.example.com", vault_path: "secret/db/creds" },
+    ],
+  },
+  oauth2: {
+    items: [
+      { name: "EntraID", provider: "azuread", client_id: "id", client_secret: "sec", enable: true },
+    ],
+  },
+  repositories: {
+    items: [
+      { name: "forms", uri: "https://git.example.com/forms.git", branch: "main", use_for_forms: true, rebase_on_start: true },
+    ],
+  },
+  ldap: {
+    server: "ldap.example.com",
+    port: 389,
+    bind_user_dn: "cn=bind,dc=example,dc=com",
+    bind_user_pw: "secret",
+    search_base: "dc=example,dc=com",
+    username_attribute: "uid",
+    enable: true,
+  },
+  settings: {
+    mail_server: "smtp.example.com",
+    mail_port: 25,
+    mail_from: "forms@example.com",
+    url: "https://forms.example.com",
+  },
+};
+
+test("validateSeed accepts a full valid seed", () => {
+  assert.equal(validateSeed(validSeed), true);
+});
+
+test("validateSeed accepts an empty seed", () => {
+  assert.equal(validateSeed({}), true);
+});
+
+test("validateSeed rejects unknown sections and unknown fields", () => {
+  assert.throws(() => validateSeed({ nonsense: {} }), /validation failed/);
+  assert.throws(
+    () => validateSeed({ awx: { items: [{ name: "x", uri: "y", bogus: true }] } }),
+    /validation failed/
+  );
+});
+
+test("validateSeed rejects missing required fields", () => {
+  // awx without uri
+  assert.throws(() => validateSeed({ awx: { items: [{ name: "x" }] } }), /validation failed/);
+  // oauth2 without client_secret
+  assert.throws(
+    () => validateSeed({ oauth2: { items: [{ name: "x", provider: "oidc", client_id: "y" }] } }),
+    /validation failed/
+  );
+  // a list section without items
+  assert.throws(() => validateSeed({ credentials: { prune: true } }), /validation failed/);
+});
+
+test("interpolateEnv resolves ${VAR} references recursively", () => {
+  const env = { AWX_TOKEN: "t0ken", LDAP_PW: "s3cret" };
+  const out = interpolateEnv(
+    {
+      awx: { items: [{ name: "tower", uri: "https://x", token: "${AWX_TOKEN}" }] },
+      ldap: { bind_user_pw: "${LDAP_PW}", server: "plain" },
+    },
+    env
+  );
+  assert.equal(out.awx.items[0].token, "t0ken");
+  assert.equal(out.ldap.bind_user_pw, "s3cret");
+  assert.equal(out.ldap.server, "plain");
+});
+
+test("interpolateEnv supports partial and repeated references", () => {
+  const env = { HOST: "example.com", PROTO: "https" };
+  const out = interpolateEnv({ url: "${PROTO}://forms.${HOST}/" }, env);
+  assert.equal(out.url, "https://forms.example.com/");
+});
+
+test("interpolateEnv reports all missing variables at once", () => {
+  assert.throws(
+    () => interpolateEnv({ a: "${MISSING_ONE}", b: "${MISSING_TWO}" }, {}),
+    /MISSING_ONE, MISSING_TWO/
+  );
+});
+
+test("interpolateEnv leaves non-strings untouched", () => {
+  const out = interpolateEnv({ port: 389, enable: true, extra: null }, {});
+  assert.equal(out.port, 389);
+  assert.equal(out.enable, true);
+  assert.equal(out.extra, null);
+});


### PR DESCRIPTION
## What

A declarative config seed: set `CONFIG_SEED_PATH` to a yaml file declaring your admin objects (awx connections, credentials, oauth2 providers, repositories, ldap, settings) and AnsibleForms applies it at startup.

We run AnsibleForms on Kubernetes with ArgoCD and everything in our stack lives in git except these objects, which so far could only be clicked together in the UI or scripted against the API. This closes that gap: with this PR (plus a ConfigMap mount) a whole instance can be rebuilt from git on an empty database, secrets included, without touching the UI once.

```yaml
version: 1
awx:
  items:
    - name: tower
      uri: https://tower.example.com
      token: ${SEED_AWX_TOKEN}
      is_default: true
repositories:
  prune: true
  items:
    - name: forms
      uri: https://git.example.com/forms.git
      branch: main
      use_for_forms: true
      rebase_on_start: true
ldap:
  server: ldap.example.com
  port: 389
  bind_user_dn: cn=bind,dc=example,dc=com
  bind_user_pw: ${SEED_LDAP_PW}
  search_base: dc=example,dc=com
  username_attribute: uid
  enable: true
```

## Semantics

* Objects coming from the seed get a `managed` flag (new column on the six tables). They are enforced on every startup and the API refuses to modify or delete them, so the file stays the source of truth. Anything created by hand in the UI is never touched.
* Removing an object from the file releases the flag (the record stays, editable again). `prune: true` on a list section deletes managed records that are no longer declared instead.
* The file carries no secrets: values like `${SEED_AWX_TOKEN}` resolve from the environment at apply time (in k8s that means a Secret via envFrom, which we feed from vault through external-secrets). For credentials the existing `vault_path` works too.
* Validation is strict (ajv, unknown fields rejected) and a broken seed makes the server refuse to start on purpose: under a rolling update the old pod keeps serving, so a typo can only block a rollout, never take a running instance down.
* On a fresh database with a seed configured the schema is created automatically (extracted `Schema.createTables()` from `Schema.create()` for that, no behavior change for the /schema endpoint).
* Users and groups are deliberately out of scope, identity is normally external (ldap/oauth2) and the initial admin is already covered by ADMIN_USERNAME/ADMIN_PASSWORD.
* The seed file is unrelated to `config.yaml` (forms configuration), hence the different name and env var.

## Implementation notes

* The upserts go through the existing models (CrudModel and friends), so encryption, is_default handling, repository cloning etc. behave exactly like a save from the UI. The models now accept an options object and only the seed passes `fromSeed`.
* The read-only guard lives centrally in `CrudModel.update/delete` (plus the ldap/settings controllers and the v1 credential model, which do raw SQL). `managed` is stripped from API payloads so it cannot be set or cleared from outside.
* The settings section only touches the mail fields and the url, `forms_yaml` and the logo survive untouched.
* New docs page (`docs/seed.md`) with a full example including the k8s wiring.
* Small unrelated fix that the e2e run surfaced: deleting a repository whose clone never succeeded threw ENOENT from `Repo.delete` (accessSync before rmSync), now it just removes the record.

## Testing

* Unit tests for the schema validation and the env interpolation (`server/tests/config-seed.test.mjs`), whole suite green (227 tests).
* Manual end to end against a fresh mysql 8 container: schema autocreation, first apply (create), reapply (idempotent update), release, prune, api guard (403 on managed objects, seed bypass works), and the three fail hard paths (bad yaml, schema violation, missing env var), all behaving as described.

A follow up we would like to do next: show the managed state in the UI (badge and read only form) instead of only failing on save, and a `POST /api/v2/config-seed/apply` endpoint so a CD hook can re-apply without a restart. Happy to adjust naming or semantics if you prefer something else.
