### PR TITLE
fix: keep target on links in html and expression fields (#480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Wizard didn't load varsFiles
+-   `target="_blank"` was stripped from links in `html` and `expression` fields, so they opened in the current tab and the form was lost (#480). `rel="noopener noreferrer"` is now forced on any link that opens a new tab
 
 ## [6.3.0] - 2026-07-31
 

--- a/client/src/components/AppForm.vue
+++ b/client/src/components/AppForm.vue
@@ -31,7 +31,7 @@ import { required, helpers, sameAs } from "@vuelidate/validators";
 import { useTemplateRef, nextTick, inject } from "vue";
 import { useAppStore } from "@/stores/app";
 import Helpers from '@/lib/Helpers';
-import DOMPurify from 'dompurify';
+import HtmlSanitizer from '@/lib/HtmlSanitizer';
 import TokenStorage from "@/lib/TokenStorage";
 import axios from "axios";
 import YAML from "yaml";
@@ -2395,7 +2395,7 @@ defineExpose({
                                     :class="{ 'text-body': !field.hide, 'text-grey': field.hide }">{{ typeof fieldLabels[field.name] === 'object' ? fieldLabels[field.name].value : fieldLabels[field.name] }}
                                 </label>
                                 
-                                <div v-show="!fieldOptions[field.name].viewable" v-html="DOMPurify.sanitize(v$.form[field.name].$model || '')"></div>
+                                <div v-show="!fieldOptions[field.name].viewable" v-html="HtmlSanitizer.sanitize(v$.form[field.name].$model)"></div>
                                 <!-- raw data -->
                                 <div @dblclick="setExpressionFieldViewable(field.name, false)"
                                     v-if="fieldOptions[field.name].viewable"

--- a/client/src/components/BsInputForForm.vue
+++ b/client/src/components/BsInputForForm.vue
@@ -9,7 +9,7 @@
   /******************************************************************/
 
   import { getCurrentInstance, computed } from "vue";
-  import DOMPurify from 'dompurify';
+  import HtmlSanitizer from '@/lib/HtmlSanitizer';
   import ace from 'ace-builds';
   import 'ace-builds/src-noconflict/mode-yaml'; // Load the language definition file used below
   import 'ace-builds/src-noconflict/theme-monokai'; // Load the theme definition file used below
@@ -24,7 +24,7 @@
   // MODEL
 
   const model = defineModel();
-  const sanitizedModel = computed(() => DOMPurify.sanitize(model.value || ''));
+  const sanitizedModel = computed(() => HtmlSanitizer.sanitize(model.value));
 
   // PROPS
 

--- a/client/src/lib/HtmlSanitizer.js
+++ b/client/src/lib/HtmlSanitizer.js
@@ -1,0 +1,42 @@
+/******************************************************************/
+/*                                                                */
+/*  AnsibleForms HTML sanitizer                                   */
+/*                                                                */
+/*  The single policy for form-authored HTML that reaches         */
+/*  v-html : `type: html` fields (AppForm) and `type: expression` */
+/*  fields rendered as html (BsInputForForm). Both went through   */
+/*  a bare DOMPurify.sanitize() before ; they share this module   */
+/*  so the policy cannot drift between them.                      */
+/*                                                                */
+/******************************************************************/
+
+import DOMPurify from 'dompurify';
+
+// DOMPurify 3.x does not carry `target` in its default attribute allowlist, so a link
+// written as <a href="..." target="_blank"> lost the attribute and opened in the current
+// tab - throwing away the form the user was filling in (issue #480). It is allowed back
+// here, and nothing else is widened : `onclick` and every other event handler is still
+// refused, and a javascript: href is still dropped even on a link that carries a target.
+export const ADD_ATTR = ['target'];
+
+// A target other than _self opens a new browsing context, and the page that lands there
+// can steer its opener through window.opener unless rel says otherwise. Browsers imply
+// noopener for target="_blank" these days but not for a named target, and the form author
+// cannot be relied on to write the rel - so it is forced on rather than expected.
+export function forceSafeRel(node) {
+  if (typeof node?.getAttribute !== 'function') return; // text/comment nodes
+  const target = node.getAttribute('target');
+  if (!target || target === '_self') return;
+  const rel = new Set((node.getAttribute('rel') || '').split(/\s+/).filter(Boolean));
+  rel.add('noopener');
+  rel.add('noreferrer');
+  node.setAttribute('rel', [...rel].join(' '));
+}
+
+DOMPurify.addHook('afterSanitizeAttributes', forceSafeRel);
+
+export function sanitize(html) {
+  return DOMPurify.sanitize(html || '', { ADD_ATTR });
+}
+
+export default { sanitize, forceSafeRel, ADD_ATTR };

--- a/client/tests/html-sanitizer.test.js
+++ b/client/tests/html-sanitizer.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import HtmlSanitizer, { ADD_ATTR, forceSafeRel, sanitize } from '../src/lib/HtmlSanitizer.js';
+
+// ─── Link targets in form HTML (issue #480) ───
+//
+// `target` is NOT in DOMPurify 3.x's default attribute allowlist, so a bare
+// DOMPurify.sanitize() dropped it and a link written with target="_blank" navigated in
+// the current tab, discarding the form the user was filling in. `ADD_ATTR` is what puts
+// it back, so it is asserted directly.
+//
+// It is asserted as CONFIGURATION rather than as sanitize() output on purpose : these
+// tests run in happy-dom, which is not a faithful enough DOM for DOMPurify to be pinned
+// by its output. Measured here - happy-dom keeps `target` even with the default config
+// (so an output assertion would pass on the unfixed code, a false green) and strips
+// block elements such as <p> and <div> that every real browser keeps. The output
+// behaviour was verified by hand against Chromium instead : with the default config
+// Chromium yields `<a href="..." rel="noopener noreferrer">`, with ADD_ATTR ['target']
+// it yields `<a href="..." target="_blank" rel="noopener noreferrer">`, and a
+// javascript: href is dropped either way.
+
+describe('HtmlSanitizer configuration', () => {
+  it('allows target back into the attribute allowlist', () => {
+    expect(ADD_ATTR).toContain('target');
+  });
+
+  it('widens nothing beyond target', () => {
+    expect(ADD_ATTR).toEqual(['target']);
+  });
+
+  it('exposes sanitize on the default export', () => {
+    expect(typeof HtmlSanitizer.sanitize).toBe('function');
+    expect(typeof sanitize('')).toBe('string');
+  });
+
+  it('treats a null or undefined value as empty', () => {
+    expect(sanitize(null)).toBe('');
+    expect(sanitize(undefined)).toBe('');
+  });
+});
+
+// ─── rel is forced, not trusted to the form author ───
+//
+// forceSafeRel is the `afterSanitizeAttributes` hook, kept pure so it can be pinned
+// without a DOM : it only ever reads and writes attributes through the node interface.
+
+function fakeNode(attributes = {}) {
+  const attrs = { ...attributes };
+  return {
+    attrs,
+    getAttribute: (name) => (name in attrs ? attrs[name] : null),
+    setAttribute: (name, value) => { attrs[name] = value; },
+  };
+}
+
+describe('forceSafeRel', () => {
+  it('forces noopener and noreferrer on target="_blank"', () => {
+    const node = fakeNode({ href: 'https://example.com', target: '_blank' });
+    forceSafeRel(node);
+    expect(node.attrs.rel.split(' ').sort()).toEqual(['noopener', 'noreferrer']);
+  });
+
+  it('forces them on a named target too, which browsers do not imply', () => {
+    const node = fakeNode({ target: 'someWindow' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toContain('noopener');
+    expect(node.attrs.rel).toContain('noreferrer');
+  });
+
+  it('keeps the rel tokens the author already wrote', () => {
+    const node = fakeNode({ target: '_blank', rel: 'nofollow' });
+    forceSafeRel(node);
+    const rel = node.attrs.rel.split(' ');
+    expect(rel).toContain('nofollow');
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  it('does not duplicate a token that is already present', () => {
+    const node = fakeNode({ target: '_blank', rel: 'noopener  noopener noreferrer' });
+    forceSafeRel(node);
+    expect(node.attrs.rel.split(' ').filter((r) => r === 'noopener')).toHaveLength(1);
+  });
+
+  it('leaves a node without a target untouched', () => {
+    const node = fakeNode({ href: 'https://example.com' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toBeUndefined();
+  });
+
+  it('leaves target="_self" untouched - it opens no new context', () => {
+    const node = fakeNode({ target: '_self' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toBeUndefined();
+  });
+
+  it('ignores a node with no attribute interface (text and comment nodes)', () => {
+    expect(() => forceSafeRel({})).not.toThrow();
+    expect(() => forceSafeRel(null)).not.toThrow();
+  });
+});

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -2724,7 +2724,10 @@
                       required: true
                       default: "2026-01"                       
               - name: html
-                description: An HTML field
+                description: |
+                  An HTML field.
+                  The html is sanitized before it is rendered : `<script>`, event handlers (`onclick`, `onerror`, ...) and `javascript:` links are always removed.
+                  A link may carry `target="_blank"` to open in a new tab ; `rel="noopener noreferrer"` is added automatically.
                 version: 4.0.9
                 examples:
                 - name: Alert
@@ -2743,6 +2746,12 @@
                       type: html
                       expression: | 
                         '<h3 class="title is-3">Your own title</h3>'          
+                - name: Link opening in a new tab
+                  code: |
+                    - type: html
+                      name: documentation
+                      expression: |
+                        '<a href="https://ansibleforms.com/" target="_blank">Read the documentation</a>'
               - name: file
                 description: A file upload field, the file is uploaded prior to the job start and the extravars will contain the uploaded file info.
                 version: 4.0.16
@@ -3901,6 +3910,8 @@
             short: Renders text as html
             description: |
               If an expression value has html tags (for example <b></b>), it will render the value as such.
+              The html is sanitized before it is rendered : `<script>`, event handlers (`onclick`, `onerror`, ...) and `javascript:` links are always removed.
+              A link may carry `target="_blank"` to open in a new tab ; `rel="noopener noreferrer"` is added automatically.
             examples:
             - name: Show bold in an expression
               code: |


### PR DESCRIPTION
Fixes #480.

## The cause

`target` is **not** in DOMPurify 3.x's default attribute allowlist — its html list runs `... 'tabindex', 'title', 'translate', 'type', 'usemap', ...` with no `target`. So the bare `DOMPurify.sanitize()` added for GHSA-wcmj-wqvw-6c88 silently dropped it, and a link in a `type: html` field (or a `type: expression` field with `isHtml`) opened in the current tab, throwing away the form the user was filling in.

Confirmed in Chromium against the reporter's own reproducer:

```
default            → <a href="https://ansibleforms.com/" rel="noopener noreferrer">open</a>
ADD_ATTR:[target]  → <a href="https://ansibleforms.com/" target="_blank" rel="noopener noreferrer">open</a>
```

## The fix

Both call sites (`AppForm.vue` for `type: html`, `BsInputForForm.vue` for `type: expression`) now go through a shared `client/src/lib/HtmlSanitizer.js`, so the policy cannot drift between them.

- `ADD_ATTR: ['target']` — and nothing else is widened.
- An `afterSanitizeAttributes` hook forces `rel="noopener noreferrer"` onto anything opening a new browsing context, so the opened page can never reach back through `window.opener`. It **merges** with the rel the author wrote instead of replacing it, and skips `target="_self"`. Browsers imply noopener for `target="_blank"` but *not* for a named target, hence the hook rather than trusting the form author.

`onclick` stays stripped, as the reporter noted — that one is the sanitizer working. Verified in Chromium against the real module:

| input | output |
|---|---|
| `<a href="…" target="_blank">` | `target="_blank" rel="noopener noreferrer"` ✅ |
| `<a target="win1" rel="nofollow">` | `rel="nofollow noopener noreferrer"` ✅ |
| `<a target="_self">` | untouched ✅ |
| `<a onclick="alert(1)" target="_blank">` | `onclick` dropped ✅ |
| `<a href="javascript:alert(1)" target="_blank">` | `href` dropped ✅ |
| `<img src=x onerror=alert(1)>` | `<img src="x">` ✅ |
| `<script>alert(1)</script><b>kept</b>` | `<b>kept</b>` ✅ |
| `<svg onload=alert(1)>` | `<svg></svg>` ✅ |

## On the tests

`client/tests/html-sanitizer.test.js` pins `ADD_ATTR` and the hook function rather than `sanitize()` output, deliberately. The client suite runs in **happy-dom**, which is not a faithful enough DOM to pin DOMPurify by its output — measured here, it keeps `target` *even with the default config* (so an output assertion would have passed on the unfixed code, a false green) and strips `<p>`/`<div>`, which every real browser keeps. The existing `xss-security.test.js` already carries a note to that effect. Real-browser behaviour was verified by hand, as above.

Each test was checked by fault injection:

| injected fault | result |
|---|---|
| `ADD_ATTR = []` (the pre-fix state) | 2 tests fail |
| rel overwritten instead of merged | 1 test fails |
| `_self` no longer exempt | 1 test fails |

## Also

- `docs/_data/help.yaml` — the `html` type and the `isHtml` property now state the sanitization policy, plus an example of a link opening in a new tab.
- `CHANGELOG.md` under Unreleased → Fixed.

## Checks

- `cd client && npm run test` — 11 files, 249 tests, all pass (11 new)
- `cd client && npm run lint:check` — 0 problems
- `cd client && npm run build` — succeeds
