### PR TITLE
fix: one source of truth for the version

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -5,9 +5,6 @@ on:
       versionName:
         description: 'Name of version  (ie 5.5.0)'
         required: true
-      versionCode:
-        description: 'Version number (50500)'
-        required: true
 permissions:
   contents: write
   pull-requests: write
@@ -28,8 +25,12 @@ jobs:
       run: |
        git config user.name "GitHub Actions"
        git config user.email noreply@github.com
-    - name: Change version number and name
-      run: printf 'ext.version_code = ${{ github.event.inputs.versionCode }}\next.version_name = "${{ github.event.inputs.versionName }}"\n' > app_versions.gradle
+    # `npm version` rather than writing the file by hand : it validates the semver, so a
+    # typo like "6.4" fails here instead of producing a bad tag and a bad image name, and
+    # it keeps package-lock.json's copy of the version in step.
+    - name: Change version number
+      working-directory: server
+      run: npm version "${{ github.event.inputs.versionName }}" --no-git-tag-version --allow-same-version
     - name: Update Changelog
       run: |
         VERSION="${{ github.event.inputs.versionName }}"
@@ -38,7 +39,7 @@ jobs:
     - name: Commit changelog and manifest files
       id: make-commit
       run: |
-        git add app_versions.gradle
+        git add server/package.json server/package-lock.json
         git add CHANGELOG.md
         git commit --message "Prepare release ${{ github.event.inputs.versionName }}"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -18,7 +18,12 @@ jobs:
                   git config user.email noreply@github.com
             - name: Setup release information
               run: |
-                  versionName=$(sed '2q;d' app_versions.gradle | cut -d "=" -f2 | xargs)
+                  # server/package.json is the single source of truth for the version : it
+                  # is what the running app reports through /api/v2/version and what
+                  # publish.sh tags the image with. This step used to read a separate
+                  # app_versions.gradle, which nothing kept in step with it - so the git
+                  # tag and the docker tag could describe different releases.
+                  versionName=$(jq -r .version server/package.json)
                   echo "VERSION_NAME=$versionName" >> $GITHUB_ENV
             - name: Extract release notes
               id: extract_release_notes

--- a/app_versions.gradle
+++ b/app_versions.gradle
@@ -1,2 +1,0 @@
-ext.version_code = 060300
-ext.version_name = "6.3.0"


### PR DESCRIPTION
The version lives in two files and different tools read different ones.

| tool | file | produces |
|---|---|---|
| `create_release_branch.yml` | **writes** `app_versions.gradle` only | the release branch |
| `tag_release.yml` | **reads** `app_versions.gradle` | the git tag + GitHub release |
| `publish.sh` / `publish-rc.sh` | **reads** `server/package.json` | the Docker image tag |

They agree today (both `6.3.0`) only because someone bumped `package.json` by hand — the workflow never touches it. **Run "Create Release Branch" for 6.4.0 as it stands and you get git tag `6.4.0` alongside a Docker image tagged `6.3.0`**, with nothing to complain about it.

## Why `server/package.json` wins

It's already the real source:

- `server/src/controllers/v2/version.controller.js:9` resolves it directly — it's what the running app reports through `/api/v2/version`, the About dialog and the Status page.
- Both publish scripts read it with `jq` to name the image.

Whereas `app_versions.gradle` was read by **exactly one step** (`tag_release.yml`), and its `version_code = 060300` — an Android-ism from the release-automation template this workflow pair was copied from — was read by **nothing at all**. I grepped the whole tree including both Dockerfiles and the publish scripts.

## Changes

- `tag_release.yml` — `versionName=$(jq -r .version server/package.json)`
- `create_release_branch.yml` — `npm version` instead of `printf`, and the now-unused `versionCode` input is dropped
- `app_versions.gradle` — deleted

## Why `npm version` rather than writing the file

Two things the hand-written `printf` never did:

- **It validates the semver.** A typo like `6.4` now fails the workflow instead of producing a bad tag and a bad image name. Verified: `npm error Invalid version: 6.4`.
- **It updates `package-lock.json`'s copy too** — both the root `version` and `packages[""].version`. Verified against a throwaway copy: all three land on `6.4.0` together.

## Note for the next release

The workflow input list is now one field, not two. `versionCode` is gone and nothing reads it.
