### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes go into the most recent release. Older releases are not patched — the
+fixes for [GHSA-g27f-cjvv-42rf](https://github.com/ansibleguy76/ansibleforms/security/advisories/GHSA-g27f-cjvv-42rf),
+[GHSA-56pr-p4x6-mwm6](https://github.com/ansibleguy76/ansibleforms/security/advisories/GHSA-56pr-p4x6-mwm6)
+and [GHSA-wcmj-wqvw-6c88](https://github.com/ansibleguy76/ansibleforms/security/advisories/GHSA-wcmj-wqvw-6c88)
+all shipped in 6.2.1 and were not backported.
+
+| Version | Supported |
+| ------- | --------- |
+| 6.3.x   | ✅        |
+| < 6.3   | ❌        |
+
+If you are running an older version, upgrading is the fix.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.** A public report tells
+everybody running AnsibleForms about the hole at the same moment it tells us, and this is
+software that holds Ansible credentials, database passwords and Vault tokens.
+
+Use **[Report a vulnerability](https://github.com/ansibleguy76/ansibleforms/security/advisories/new)**
+on the Security tab. That opens a private advisory visible only to you and the
+maintainers, and it is the same mechanism the three advisories above went through.
+
+If that page is not available to you, open a normal issue saying only that you have a
+security report and asking for a private channel — **no details, no reproducer, no
+version numbers**. A maintainer will open a private advisory and invite you to it.
+
+## What to include
+
+The more of this you can give, the faster it gets fixed:
+
+- what an attacker achieves — read another user's data, run a playbook they may not run,
+  reach the host, escalate to admin
+- the version, and how it is deployed (docker, kubernetes, bare node)
+- a reproducer, or the request that triggers it
+- whether authentication is needed, and with which role options
+
+## What to expect
+
+- an acknowledgement that the report arrived, and whether it is reproducible
+- if it is accepted, a fix in the next release and a published advisory crediting you
+  unless you would rather not be named
+- if it is declined, the reasoning — usually that the behaviour needs a permission the
+  reporter already had
+
+## Scope
+
+In scope: anything reachable by an authenticated user beyond the permissions their role
+grants, anything reachable with no authentication at all, stored credentials becoming
+readable or loggable, and injection into the shell, the database or the browser.
+
+Out of scope: findings that need the admin account to already be compromised (an admin can
+run arbitrary playbooks by design — that is the product), and reports produced by a
+scanner with no demonstrated impact.


### PR DESCRIPTION
There are three published advisories against this code and **no documented way to report a fourth privately.** The only path a finder has today is a public issue — which tells everybody running AnsibleForms about the hole at the same moment it tells you. For software that holds Ansible credentials, database passwords and Vault tokens, that's the wrong default.

`SECURITY.md` also gets surfaced by GitHub on the repo sidebar, in the new-issue chooser and in the advisory flow, so it's the file that actually redirects that traffic.

## ⚠️ One setting has to change for this to work

**Private vulnerability reporting is currently disabled on this repository.** I checked:

```
$ gh api repos/ansibleguy76/ansibleforms/private-vulnerability-reporting
{"enabled":false}
```

So the "Report a vulnerability" button doesn't exist yet, and the link in this file 404s until you enable it: **Settings → Code security and analysis → Private vulnerability reporting → Enable**. It's free, one click, and it's the same mechanism the three existing advisories went through.

Because I can't enable it from here, the policy carries a fallback that works today: open a normal issue saying only that you have a security report and asking for a private channel — no details, no reproducer, no version numbers.

## What it says

- **Supported versions** — only the most recent gets fixes, which matches what actually happened: GHSA-g27f-cjvv-42rf, GHSA-56pr-p4x6-mwm6 and GHSA-wcmj-wqvw-6c88 all shipped in 6.2.1 and none were backported.
- **How to report**, with the fallback above.
- **What to include** — impact, version, deployment shape, reproducer, whether auth is needed and with which role options.
- **What to expect** — acknowledgement, a fix in the next release with credit, or the reasoning if declined.
- **Scope** — in: anything reachable beyond a role's permissions, anything unauthenticated, stored credentials becoming readable, injection into shell/database/browser. Out: findings that need the admin account already compromised (an admin can run arbitrary playbooks *by design* — that's the product), and scanner output with no demonstrated impact.

## Two things worth your judgement

I deliberately avoided **any response-time commitment** — a policy that promises 48 hours and doesn't deliver is worse than one that promises nothing. Add an SLA if you want one.

I also avoided **inventing a contact email**, since there isn't one anywhere in the repo or the manifests. If you'd rather have one listed, that's a one-line addition.
