### PR TITLE
build: pin the docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
-FROM ansibleguy/ansibleforms-base:latest AS nodebase
+# The base image is pinned by DIGEST, not by :latest. It is only ever published as
+# :latest (publish-base.sh), so a rebuild of the base silently changed what every
+# application build started from - with no commit here to show for it. Updating the pin
+# is now a deliberate, reviewable act.
+#
+#   docker pull ansibleguy/ansibleforms-base:latest
+#   docker inspect --format='{{index .RepoDigests 0}}' ansibleguy/ansibleforms-base:latest
+#
+FROM ansibleguy/ansibleforms-base:latest@sha256:8a1ea5dd0a80be59ce78b4520893e0d42dc0d1231c0af02064a48bce5aad4b23 AS nodebase
 
 ##################################################
 # builder stage
 # intermediate build to compile the client application with vite
 # can run in parallel with base stage
 
-FROM ansibleguy/ansibleforms-base:latest AS tmp_builder
+FROM ansibleguy/ansibleforms-base:latest@sha256:8a1ea5dd0a80be59ce78b4520893e0d42dc0d1231c0af02064a48bce5aad4b23 AS tmp_builder
 
 # Build arguments for git SHA and build time
 ARG GIT_SHA=unknown

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,8 @@
-FROM node:lts-bookworm-slim
+# node:lts is a MOVING target - it is 24 today (identical digest to node:24-bookworm-slim)
+# and will become 26 without a commit here. Pinned to the major it already resolves to, so
+# this is not a version change ; see the PR for the separate question of whether the image
+# should run 24 while .nvmrc and CI say 22.
+FROM node:24-bookworm-slim
 
 # Use /app as CWD
 WORKDIR /app


### PR DESCRIPTION
Both `FROM` lines were moving targets, so the shipped artifact could change with **no commit in this repository to show for it** — and you'd find out on release day.

| file | was | now |
|---|---|---|
| `Dockerfile` (×2) | `ansibleguy/ansibleforms-base:latest` | pinned by digest `sha256:8a1ea5dd…` |
| `Dockerfile.base` | `node:lts-bookworm-slim` | `node:24-bookworm-slim` |

`ansibleguy/ansibleforms-base` is only ever published as `:latest` (`publish-base.sh` line 19) and has **no version tags at all** — I checked Docker Hub, `latest` is the only one. So a digest is the only way to pin it. The command to read a new digest is in a comment above the `FROM`:

```
docker inspect --format='{{index .RepoDigests 0}}' ansibleguy/ansibleforms-base:latest
```

**Neither change alters what gets built today.** `node:lts-bookworm-slim` and `node:24-bookworm-slim` currently have identical digests (`sha256:3638d9a6…`), so pinning to 24 is naming what was already happening.

## Verified

- both references resolve via `docker manifest inspect`
- the full image builds from the pinned base
- it runs **`node v24.16.0`**, exactly as before the pin

## ⚠️ What the verification turned up

`node:lts` resolving to 24 means **the shipped image has been running Node 24 while `.nvmrc` says 22** — so CI (which reads `.nvmrc`) tests on a different major than production runs:

```
image   → v24.16.0
.nvmrc  → 22
```

That's not created by this PR and I haven't changed it — pinning to the major it already used is the behaviour-preserving move, and silently downgrading production to 22 inside a "pin the base image" PR would be exactly the kind of hidden change this PR exists to prevent.

But it's worth deciding deliberately, and it's a one-line change either way:

- **bump `.nvmrc` to 24** so dev and CI match production, or
- **pin the image to `node:22-bookworm-slim`** so production matches what the tests actually cover

I'd lean to the first — 24 is current LTS and it's what has been shipping for months — but it means the test suite starts running on a major it has never run on, so it wants its own PR and a green run rather than a footnote in this one.

## Follow-up worth considering

`publish-base.sh` could tag a version alongside `:latest` (`ansibleguy/ansibleforms-base:24-<date>`), which would make the pin readable instead of a hash. Not done here to keep this PR to one thing.
