### PR TITLE
ci: run the suite daily as well as on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,16 @@ on:
     branches: [develop, main]
   push:
     branches: [develop]
+  # Daily, because some things break with no commit at all and a PR-triggered run only
+  # ever asks about changes. This repository has already had one: a retention test dated
+  # its fixtures relative to a fixed day and measured them against the real clock, so it
+  # went red on its own and stayed red for ten days - the discovery path was an innocent
+  # contributor opening a PR and being unable to tell whether they had broken it.
+  # It costs about two minutes and is free on a public repository, so daily rather than
+  # weekly : the only difference is whether that sits for a day or for a week.
+  # Note GitHub disables scheduled workflows after 60 days of repository inactivity.
+  schedule:
+    - cron: '40 3 * * *'
 
 permissions:
   contents: read
@@ -32,6 +42,11 @@ jobs:
         working-directory: client
     steps:
       - uses: actions/checkout@v6
+        with:
+          # a scheduled run fires on the DEFAULT branch (main) ; test develop,
+          # which is where the work lands. '' is checkout's own default for every
+          # other event, so pull requests keep checking out their merge ref.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
       - uses: actions/setup-node@v4
         with:
@@ -60,6 +75,11 @@ jobs:
         working-directory: server
     steps:
       - uses: actions/checkout@v6
+        with:
+          # a scheduled run fires on the DEFAULT branch (main) ; test develop,
+          # which is where the work lands. '' is checkout's own default for every
+          # other event, so pull requests keep checking out their merge ref.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
       - uses: actions/setup-node@v4
         with:
@@ -85,6 +105,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # a scheduled run fires on the DEFAULT branch (main) ; test develop,
+          # which is where the work lands. '' is checkout's own default for every
+          # other event, so pull requests keep checking out their merge ref.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
       # server/schema/public/*.json is generated but committed, and it is only
       # regenerated inside publish.sh / publish-rc.sh - so it silently goes stale

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+# Runs on every pull request, and on develop after a merge.
+#
+# Client and server are separate jobs so they run in parallel - the server suite is the
+# long pole (~1 minute) and the client is a few seconds plus a build.
+#
+# No secrets are used anywhere in this workflow, which is deliberate : pull requests come
+# from forks, and a fork's GITHUB_TOKEN is read-only with no access to secrets. A check
+# that needed one would simply never run on the PRs that matter.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+# a new push to the same PR cancels the run it supersedes
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  client:
+    name: Client
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      # `npm ci` from client/package-lock.json - the root lockfile is not in the repo
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      # No database service on purpose. The suite runs against the stubs in
+      # tests/__mocks__, and the schema tests read src/db/*.sql as TEXT rather than
+      # executing it. A MySQL service here would slow every run and invite tests that
+      # depend on one ; if integration coverage is ever wanted, give it its own workflow.
+      - name: Test
+        run: npm run test
+
+  schema:
+    name: Public schema is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # server/schema/public/*.json is generated but committed, and it is only
+      # regenerated inside publish.sh / publish-rc.sh - so it silently goes stale
+      # between releases. jq is preinstalled on the runner.
+      - name: Regenerate
+        run: ./server/schema/build-public-schema.sh
+
+      - name: Fail if the committed copy differs
+        run: |
+          if ! git diff --quiet -- server/schema/public; then
+            echo "::error::server/schema/public is out of date - run ./server/schema/build-public-schema.sh and commit the result"
+            git diff -- server/schema/public
+            exit 1
+          fi
+          echo "server/schema/public matches the authoritative schema"
+
+  dependencies:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      # flags a dependency the PR adds that has a known advisory
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: Security
 
 # Static analysis for the client and the server. This repository has three published
 # advisories against its own code (GHSA-g27f-cjvv-42rf, GHSA-56pr-p4x6-mwm6,
@@ -23,7 +23,10 @@ concurrency:
 
 jobs:
   analyze:
-    name: Analyze
+    # reads as "Security / CodeQL". GitHub separately posts its own
+    # "Code scanning results / CodeQL" check when the SARIF is uploaded - that one is
+    # emitted by the code scanning service, not by Actions, and cannot be renamed here.
+    name: CodeQL
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,11 +25,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    # A pull request from a FORK gets a read-only token, which cannot upload the SARIF
-    # result - so it is skipped there rather than left to fail a check on every PR.
-    # Nothing goes unanalysed : the push to develop and the weekly run still cover it.
-    # Drop this line if fork uploads turn out to work on this repository's plan.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Static analysis for the client and the server. This repository has three published
+# advisories against its own code (GHSA-g27f-cjvv-42rf, GHSA-56pr-p4x6-mwm6,
+# GHSA-wcmj-wqvw-6c88), which is the argument for running this on every pull request
+# rather than only on a schedule.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+  schedule:
+    # Mondays 04:17 UTC - an hour no in-process cron task of the app itself occupies
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    # A pull request from a FORK gets a read-only token, which cannot upload the SARIF
+    # result - so it is skipped there rather than left to fail a check on every PR.
+    # Nothing goes unanalysed : the push to develop and the weekly run still cover it.
+    # Drop this line if fork uploads turn out to work on this repository's plan.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      # no build step - javascript is analysed from source
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker build
+
+# Builds the image without pushing it, so "does the image still assemble" is answered at
+# review time instead of by hand during publish.sh. Path-filtered because it is the slow
+# one - it runs npm ci and a vite build inside the image - and for that reason it is not
+# a check worth requiring in branch protection.
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'Dockerfile'
+      - 'Dockerfile.base'
+      - 'client/package.json'
+      - 'client/package-lock.json'
+      - 'server/package.json'
+      - 'server/package-lock.json'
+      - 'generate-build-info.sh'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker build
+name: Docker
 
 # Builds the image without pushing it, so "does the image still assemble" is answered at
 # review time instead of by hand during publish.sh. Path-filtered because it is the slow

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,9 @@ concurrency:
 
 jobs:
   build:
-    # this is the check name a pull request shows - keep it distinct from the docker
-    # workflow's "Build image", and note that renaming it breaks any branch protection
-    # rule that requires it
-    name: Docs build
+    # reads as "Docs / Build" where the workflow name prefixes the job. Note that
+    # renaming it breaks any branch protection rule that requires it
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,7 +68,7 @@ jobs:
           path: docs/_site
 
   deploy:
-    name: Docs deploy
+    name: Deploy
     if: github.event_name != 'pull_request'
     environment:
       name: github-pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,18 @@
 name: Deploy Jekyll site to Pages
 
+# A pull request BUILDS the site but does not deploy it. docs/_data/help.yaml is the
+# single source of truth for the settings pages and is read by four tests, so a malformed
+# edit used to be discovered only after the merge, when this workflow failed on develop.
+
 on:
   push:
     branches: ["develop"]
+  pull_request:
+    branches: ["develop", "main"]
+    paths:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -11,8 +21,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  # deploys keep the single "pages" group and are never cancelled ; each PR gets its own
+  group: pages-${{ github.event.pull_request.number || 'deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -33,22 +44,28 @@ jobs:
           cache-version: 0
           working-directory: docs
       
+      # skipped on a pull request : it calls the Pages API, and a fork's token cannot.
+      # base_path is then empty, which jekyll reads as the site root - fine for a build
+      # that is only ever thrown away.
       - name: Setup Pages
         id: pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v4
-      
+
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         working-directory: docs
         env:
           JEKYLL_ENV: production
-      
+
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_site
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll site to Pages
+name: Docs
 
 # A pull request BUILDS the site but does not deploy it. docs/_data/help.yaml is the
 # single source of truth for the settings pages and is read by four tests, so a malformed
@@ -27,6 +27,10 @@ concurrency:
 
 jobs:
   build:
+    # this is the check name a pull request shows - keep it distinct from the docker
+    # workflow's "Build image", and note that renaming it breaks any branch protection
+    # rule that requires it
+    name: Docs build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,6 +69,7 @@ jobs:
           path: docs/_site
 
   deploy:
+    name: Docs deploy
     if: github.event_name != 'pull_request'
     environment:
       name: github-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Wizard didn't load varsFiles
+-   `target="_blank"` was stripped from links in `html` and `expression` fields, so they opened in the current tab and the form was lost (#480). `rel="noopener noreferrer"` is now forced on any link that opens a new tab
 
 ## [6.3.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Wizard didn't load varsFiles
 -   `target="_blank"` was stripped from links in `html` and `expression` fields, so they opened in the current tab and the form was lost (#480). `rel="noopener noreferrer"` is now forced on any link that opens a new tab
+-   Startup failed with `Failed to create the path for the log files` when `LOG_PATH`'s parent folder did not exist — the folder is now created recursively
 
 ## [6.3.0] - 2026-07-31
 

--- a/client/src/components/AppForm.vue
+++ b/client/src/components/AppForm.vue
@@ -31,7 +31,7 @@ import { required, helpers, sameAs } from "@vuelidate/validators";
 import { useTemplateRef, nextTick, inject } from "vue";
 import { useAppStore } from "@/stores/app";
 import Helpers from '@/lib/Helpers';
-import DOMPurify from 'dompurify';
+import HtmlSanitizer from '@/lib/HtmlSanitizer';
 import TokenStorage from "@/lib/TokenStorage";
 import axios from "axios";
 import YAML from "yaml";
@@ -2395,7 +2395,7 @@ defineExpose({
                                     :class="{ 'text-body': !field.hide, 'text-grey': field.hide }">{{ typeof fieldLabels[field.name] === 'object' ? fieldLabels[field.name].value : fieldLabels[field.name] }}
                                 </label>
                                 
-                                <div v-show="!fieldOptions[field.name].viewable" v-html="DOMPurify.sanitize(v$.form[field.name].$model || '')"></div>
+                                <div v-show="!fieldOptions[field.name].viewable" v-html="HtmlSanitizer.sanitize(v$.form[field.name].$model)"></div>
                                 <!-- raw data -->
                                 <div @dblclick="setExpressionFieldViewable(field.name, false)"
                                     v-if="fieldOptions[field.name].viewable"

--- a/client/src/components/BsInputForForm.vue
+++ b/client/src/components/BsInputForForm.vue
@@ -9,7 +9,7 @@
   /******************************************************************/
 
   import { getCurrentInstance, computed } from "vue";
-  import DOMPurify from 'dompurify';
+  import HtmlSanitizer from '@/lib/HtmlSanitizer';
   import ace from 'ace-builds';
   import 'ace-builds/src-noconflict/mode-yaml'; // Load the language definition file used below
   import 'ace-builds/src-noconflict/theme-monokai'; // Load the theme definition file used below
@@ -24,7 +24,7 @@
   // MODEL
 
   const model = defineModel();
-  const sanitizedModel = computed(() => DOMPurify.sanitize(model.value || ''));
+  const sanitizedModel = computed(() => HtmlSanitizer.sanitize(model.value));
 
   // PROPS
 

--- a/client/src/lib/HtmlSanitizer.js
+++ b/client/src/lib/HtmlSanitizer.js
@@ -1,0 +1,42 @@
+/******************************************************************/
+/*                                                                */
+/*  AnsibleForms HTML sanitizer                                   */
+/*                                                                */
+/*  The single policy for form-authored HTML that reaches         */
+/*  v-html : `type: html` fields (AppForm) and `type: expression` */
+/*  fields rendered as html (BsInputForForm). Both went through   */
+/*  a bare DOMPurify.sanitize() before ; they share this module   */
+/*  so the policy cannot drift between them.                      */
+/*                                                                */
+/******************************************************************/
+
+import DOMPurify from 'dompurify';
+
+// DOMPurify 3.x does not carry `target` in its default attribute allowlist, so a link
+// written as <a href="..." target="_blank"> lost the attribute and opened in the current
+// tab - throwing away the form the user was filling in (issue #480). It is allowed back
+// here, and nothing else is widened : `onclick` and every other event handler is still
+// refused, and a javascript: href is still dropped even on a link that carries a target.
+export const ADD_ATTR = ['target'];
+
+// A target other than _self opens a new browsing context, and the page that lands there
+// can steer its opener through window.opener unless rel says otherwise. Browsers imply
+// noopener for target="_blank" these days but not for a named target, and the form author
+// cannot be relied on to write the rel - so it is forced on rather than expected.
+export function forceSafeRel(node) {
+  if (typeof node?.getAttribute !== 'function') return; // text/comment nodes
+  const target = node.getAttribute('target');
+  if (!target || target === '_self') return;
+  const rel = new Set((node.getAttribute('rel') || '').split(/\s+/).filter(Boolean));
+  rel.add('noopener');
+  rel.add('noreferrer');
+  node.setAttribute('rel', [...rel].join(' '));
+}
+
+DOMPurify.addHook('afterSanitizeAttributes', forceSafeRel);
+
+export function sanitize(html) {
+  return DOMPurify.sanitize(html || '', { ADD_ATTR });
+}
+
+export default { sanitize, forceSafeRel, ADD_ATTR };

--- a/client/tests/html-sanitizer.test.js
+++ b/client/tests/html-sanitizer.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import HtmlSanitizer, { ADD_ATTR, forceSafeRel, sanitize } from '../src/lib/HtmlSanitizer.js';
+
+// ─── Link targets in form HTML (issue #480) ───
+//
+// `target` is NOT in DOMPurify 3.x's default attribute allowlist, so a bare
+// DOMPurify.sanitize() dropped it and a link written with target="_blank" navigated in
+// the current tab, discarding the form the user was filling in. `ADD_ATTR` is what puts
+// it back, so it is asserted directly.
+//
+// It is asserted as CONFIGURATION rather than as sanitize() output on purpose : these
+// tests run in happy-dom, which is not a faithful enough DOM for DOMPurify to be pinned
+// by its output. Measured here - happy-dom keeps `target` even with the default config
+// (so an output assertion would pass on the unfixed code, a false green) and strips
+// block elements such as <p> and <div> that every real browser keeps. The output
+// behaviour was verified by hand against Chromium instead : with the default config
+// Chromium yields `<a href="..." rel="noopener noreferrer">`, with ADD_ATTR ['target']
+// it yields `<a href="..." target="_blank" rel="noopener noreferrer">`, and a
+// javascript: href is dropped either way.
+
+describe('HtmlSanitizer configuration', () => {
+  it('allows target back into the attribute allowlist', () => {
+    expect(ADD_ATTR).toContain('target');
+  });
+
+  it('widens nothing beyond target', () => {
+    expect(ADD_ATTR).toEqual(['target']);
+  });
+
+  it('exposes sanitize on the default export', () => {
+    expect(typeof HtmlSanitizer.sanitize).toBe('function');
+    expect(typeof sanitize('')).toBe('string');
+  });
+
+  it('treats a null or undefined value as empty', () => {
+    expect(sanitize(null)).toBe('');
+    expect(sanitize(undefined)).toBe('');
+  });
+});
+
+// ─── rel is forced, not trusted to the form author ───
+//
+// forceSafeRel is the `afterSanitizeAttributes` hook, kept pure so it can be pinned
+// without a DOM : it only ever reads and writes attributes through the node interface.
+
+function fakeNode(attributes = {}) {
+  const attrs = { ...attributes };
+  return {
+    attrs,
+    getAttribute: (name) => (name in attrs ? attrs[name] : null),
+    setAttribute: (name, value) => { attrs[name] = value; },
+  };
+}
+
+describe('forceSafeRel', () => {
+  it('forces noopener and noreferrer on target="_blank"', () => {
+    const node = fakeNode({ href: 'https://example.com', target: '_blank' });
+    forceSafeRel(node);
+    expect(node.attrs.rel.split(' ').sort()).toEqual(['noopener', 'noreferrer']);
+  });
+
+  it('forces them on a named target too, which browsers do not imply', () => {
+    const node = fakeNode({ target: 'someWindow' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toContain('noopener');
+    expect(node.attrs.rel).toContain('noreferrer');
+  });
+
+  it('keeps the rel tokens the author already wrote', () => {
+    const node = fakeNode({ target: '_blank', rel: 'nofollow' });
+    forceSafeRel(node);
+    const rel = node.attrs.rel.split(' ');
+    expect(rel).toContain('nofollow');
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  it('does not duplicate a token that is already present', () => {
+    const node = fakeNode({ target: '_blank', rel: 'noopener  noopener noreferrer' });
+    forceSafeRel(node);
+    expect(node.attrs.rel.split(' ').filter((r) => r === 'noopener')).toHaveLength(1);
+  });
+
+  it('leaves a node without a target untouched', () => {
+    const node = fakeNode({ href: 'https://example.com' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toBeUndefined();
+  });
+
+  it('leaves target="_self" untouched - it opens no new context', () => {
+    const node = fakeNode({ target: '_self' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toBeUndefined();
+  });
+
+  it('ignores a node with no attribute interface (text and comment nodes)', () => {
+    expect(() => forceSafeRel({})).not.toThrow();
+    expect(() => forceSafeRel(null)).not.toThrow();
+  });
+});

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -2724,7 +2724,10 @@
                       required: true
                       default: "2026-01"                       
               - name: html
-                description: An HTML field
+                description: |
+                  An HTML field.
+                  The html is sanitized before it is rendered : `<script>`, event handlers (`onclick`, `onerror`, ...) and `javascript:` links are always removed.
+                  A link may carry `target="_blank"` to open in a new tab ; `rel="noopener noreferrer"` is added automatically.
                 version: 4.0.9
                 examples:
                 - name: Alert
@@ -2743,6 +2746,12 @@
                       type: html
                       expression: | 
                         '<h3 class="title is-3">Your own title</h3>'          
+                - name: Link opening in a new tab
+                  code: |
+                    - type: html
+                      name: documentation
+                      expression: |
+                        '<a href="https://ansibleforms.com/" target="_blank">Read the documentation</a>'
               - name: file
                 description: A file upload field, the file is uploaded prior to the job start and the extravars will contain the uploaded file info.
                 version: 4.0.16
@@ -3901,6 +3910,8 @@
             short: Renders text as html
             description: |
               If an expression value has html tags (for example <b></b>), it will render the value as such.
+              The html is sanitized before it is rendered : `<script>`, event handlers (`onclick`, `onerror`, ...) and `javascript:` links are always removed.
+              A link may carry `target="_blank"` to open in a new tab ; `rel="noopener noreferrer"` is added automatically.
             examples:
             - name: Show bold in an expression
               code: |

--- a/server/config/log.config.js
+++ b/server/config/log.config.js
@@ -23,8 +23,12 @@ var log_config = {
 };
 if ( !fs.existsSync( log_config.path ) ) {
   try{
-    // Create the directory if it does not exist
-    fs.mkdirSync( log_config.path );
+    // Create the directory if it does not exist.
+    // `recursive` matters : the default LOG_PATH is ./persistent/logs and persistent/ is
+    // gitignored, so on a fresh clone the parent does not exist either and a plain mkdir
+    // fails with ENOENT - taking 22 test suites and `npm run dev` down with it. That is
+    // what "server/persistent/ must exist" was a manual workaround for.
+    fs.mkdirSync( log_config.path, { recursive: true } );
   }catch(err){
     throw new Error("Failed to create the path for the log files", { cause: err })
   }

--- a/server/tests/retention-zero.test.mjs
+++ b/server/tests/retention-zero.test.mjs
@@ -11,12 +11,21 @@
 // 'restore points never' for 0, with the note "0 deletes nothing, for every one of these" -
 // so the code was what was wrong, not the note. That claim is asserted here too: a page
 // whose premise is never claiming an unearned fact must not be the thing that is lying.
-import { test, describe, expect, vi, beforeEach } from "vitest";
+import { test, describe, expect, vi, beforeEach, afterEach } from "vitest";
 
 process.env.DB_HOST ||= "127.0.0.1";
 process.env.DB_PORT ||= "3306";
 process.env.DB_USER ||= "test";
 process.env.DB_PASSWORD ||= "test";
+
+// The fixtures below are dated relative to a fixed day, but removeOld measures them
+// against the real clock - so they aged with the calendar and the file went red on
+// 2026-08-01, when the 60-day-old snapshot became 61 real days old and started being
+// pruned. The clock is frozen instead, and the timezone pinned with it : removeOld
+// parses the date part as LOCAL midnight, so under UTC+13 or further the same stamp
+// is a day older than it reads. Both have to be set before the model is imported.
+process.env.TZ = "UTC";
+const NOW = Date.UTC(2026, 6, 31, 12);
 
 // a backup folder holding snapshots of various ages
 const removed = [];
@@ -40,14 +49,21 @@ const Form = (await import("../src/models/form.model.js")).default;
 
 // 'YYYYMMDDHHmmssSSS' - 17 digits, which is what removeOld filters on
 function stamp(daysAgo) {
-  const d = new Date(Date.UTC(2026, 6, 31) - daysAgo * 86400000);
+  const d = new Date(NOW - daysAgo * 86400000);
   const p = (n, w = 2) => String(n).padStart(w, "0");
   return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}120000000`;
 }
 
 beforeEach(() => {
+  // only Date is faked - the model uses no timers, and faking those would hang vitest
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
   removed.length = 0;
   entries = [90, 61, 60, 30, 1, 0].map((n) => `config.yaml.bak.${stamp(n)}`);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("OLD_BACKUP_DAYS", () => {


### PR DESCRIPTION
> **Stacked on #484.** Until that merges, the diff below shows its commits too. Merge #484 first and this shrinks to the one file.

A PR-triggered run only ever asks about **changes**. Some things break with no commit at all, and this repo has already had one: `retention-zero.test.mjs` dated its fixtures relative to a fixed day and measured them against the real clock, so it went red on its own on 1 August and stayed red for ten days. The realistic discovery path was a contributor opening an unrelated PR, seeing `Server ✗`, and being unable to tell whether they'd broken it or inherited it.

Daily rather than weekly — it's two minutes and free on a public repo, so a longer interval only buys a longer time to notice.

## The scheduling detail that needed handling

**Scheduled runs fire on the default branch, which is `main`** — not develop. So without care, a nightly run would have tested the last release rather than the branch where work lands. The three jobs now check out develop explicitly:

```yaml
ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
```

`''` is checkout's own default for every other event, so pull requests keep checking out their merge ref exactly as before. The dependency-review job is untouched — it's already gated to `pull_request`.

## Two caveats, worth knowing rather than discovering

1. **This won't fire until `ci.yml` reaches `main`.** GitHub reads the schedule from the default branch, and `main` currently has only the three release workflows. So it starts working at the next release. Nothing to fix — just don't expect a nightly run tomorrow.
2. **GitHub disables scheduled workflows after 60 days of repository inactivity** — i.e. during exactly the quiet stretch this is meant to cover. If the repo goes quiet, it needs re-enabling from the Actions tab.

## What it would have caught

The date bomb, within a day instead of ten. Beyond that: a runner image roll, a `setup-node` 22.x bump, and any future fixture that quietly ages out. Since `npm ci` installs from the lockfile, the suite is otherwise fairly deterministic — most nights this will do nothing, which is the point.
