### PR TITLE
docs: contributing guide and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Base branch should be `develop`, not `main`. See CONTRIBUTING.md.
+Security problem? Do not open a PR or an issue - see SECURITY.md.
+-->
+
+## What this changes
+
+<!-- One or two sentences. If it fixes an issue, "Fixes #123" here. -->
+
+## Why
+
+<!-- What breaks without it, or what it makes possible. -->
+
+## How it was verified
+
+<!--
+What you actually ran, not what you assume. Reverting the fix and watching the test
+fail is worth more than the test passing.
+-->
+
+- [ ] `cd client && npm run lint:check && npm run test && npm run build`
+- [ ] `cd server && npm run lint:check && npm run test`
+
+## Checklist
+
+- [ ] Base branch is `develop`
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]`, if a user or operator would notice
+- [ ] UI strings added to **all six** locale files (`en`, `de`, `fr`, `it`, `es`, `nl`)
+- [ ] New page has a router entry with a `beforeEnter` guard, and a matching sidebar `permission:`
+- [ ] New database column is in **both** the schema patch and `create_schema_and_tables.sql`, plus `SCHEMA_MANIFEST`
+- [ ] New environment variable has a `docs/_data/help.yaml` entry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to AnsibleForms
+
+Thanks for helping out. This is the short version of everything you need to know before
+opening a pull request.
+
+## Pull requests go to `develop`, not `main`
+
+`main` is the released code. `develop` is where work lands, and releases are cut from it
+by the **Create Release Branch** workflow. A PR opened against `main` will be asked to
+retarget, so save yourself the round trip.
+
+## Found a security problem?
+
+**Do not open an issue.** See [SECURITY.md](SECURITY.md) — there is a private channel for
+it, because this software holds Ansible credentials, database passwords and Vault tokens.
+
+## Running it locally
+
+```bash
+npm run dev          # both halves: server on :3001, client on https://localhost:8443
+```
+
+The client uses a self-signed certificate, so the browser will warn on first visit. The
+default login is `admin` / `AnsibleForms!123`.
+
+You need a MySQL 8 (or MariaDB) instance and a `server/.env.development` telling the server
+how to reach it — `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`. Against an empty database
+the schema builds itself at startup.
+
+## Before you push
+
+CI runs exactly these, so running them first saves a round trip:
+
+```bash
+cd client && npm run lint:check && npm run test && npm run build
+cd server && npm run lint:check && npm run test
+```
+
+Both sides are lint-clean and green, and the intent is to keep them that way. The server
+suite needs no database — it runs against the stubs in `server/tests/__mocks__`.
+
+## Things that are easy to get wrong
+
+**Six locale files, always.** Every UI string goes through `t('key')`, and
+`client/src/locales/` holds `en`, `de`, `fr`, `it`, `es` and `nl`. They are at exact
+parity: same keys, same `{placeholder}` tokens. Adding a string to one and not the others
+ships a missing translation. Server strings live in `server/src/locales/`, same six.
+
+**Adding a page does not add a route.** `client/src/router/index.js` is hand-written, one
+entry per page with its own `beforeEnter` guard. The guard has to match the permission the
+page's API actually requires, and the sidebar entry in `AppSidebar.vue` needs the same
+`permission:` value.
+
+**Permission failures answer `403`, never `401`.** A global axios interceptor treats any
+401 as a dead session and logs the user out, so a 401 for "you may not do this" throws the
+user to the login page instead of showing an error. Add new permissions through the
+`permissionGuard` helper in `server/src/lib/middleware.js`.
+
+**A database column needs two edits.** `server/src/models/schema.model.js` (the patch, for
+existing installs) *and* `server/src/db/create_schema_and_tables.sql` (for fresh ones), plus
+an entry in `SCHEMA_MANIFEST` or the Status page will report a database as complete when it
+is not. Note that SQL file **drops every table** — never run it against anything you care
+about.
+
+**Environment variables need a `docs/_data/help.yaml` entry.** That file is the single
+source of truth for the label, the help text, the type and the allowed values. A variable
+missing from it appears nowhere in the settings UI.
+
+## Commit messages and changelog
+
+Conventional-ish prefixes (`fix:`, `feat:`, `ci:`, `docs:`, `chore:`) are the norm. Add a
+line to `CHANGELOG.md` under `## [Unreleased]` for anything a user or an operator would
+notice — the release workflow turns that section into the release notes.
+
+## Questions
+
+Open a discussion or an issue. A draft PR with a question in it is also fine — it is
+usually the fastest way to find out whether an approach fits.


### PR DESCRIPTION
The repo has issue templates but nothing telling a contributor that **PRs go to `develop`, not `main`** — the first mistake an outside contributor makes, and it costs a round trip every time. GitHub surfaces `CONTRIBUTING.md` on the new-issue and new-PR screens, so it's the file that actually intercepts that.

## `CONTRIBUTING.md`

- PRs target `develop`; `main` is released code
- security problems go to SECURITY.md, not an issue
- how to run it locally, and the two command lines CI will run anyway
- the rules that are invisible from the code, each of which has caused a real bug:
  - **six locale files at exact parity** — same keys, same `{placeholder}` tokens
  - **adding a page file creates no route** — `router/index.js` is hand-written, one entry per page with a `beforeEnter` guard, and the sidebar `permission:` has to match it
  - **403, never 401, for a permission failure** — a global axios interceptor treats any 401 as a dead session and logs the user out
  - **a database column needs three edits** — the schema patch, `create_schema_and_tables.sql`, and `SCHEMA_MANIFEST`
  - **an env var needs a `help.yaml` entry** or it appears nowhere in the UI

## `.github/PULL_REQUEST_TEMPLATE.md`

What changed, why, and **how it was verified** — asking what was actually run rather than for a promise, with a note that reverting a fix and watching the test fail is worth more than the test passing. Then a checklist of the five traps above.

## Judgement calls

I kept it **short and specific to this codebase** rather than writing a generic contributing guide. Every rule listed is one that has produced a bug here — a document full of advice nobody needs is one nobody reads.

The template checklist is deliberately not a wall: five items, each of which fails silently if missed. Trim it if you find it heavy — a template people delete unread is worse than none.
