### PR TITLE
ci: report test coverage in the job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI
+
+# Runs on every pull request, and on develop after a merge.
+#
+# Client and server are separate jobs so they run in parallel - the server suite is the
+# long pole (~1 minute) and the client is a few seconds plus a build.
+#
+# No secrets are used anywhere in this workflow, which is deliberate : pull requests come
+# from forks, and a fork's GITHUB_TOKEN is read-only with no access to secrets. A check
+# that needed one would simply never run on the PRs that matter.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+# a new push to the same PR cancels the run it supersedes
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  client:
+    name: Client
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      # `npm ci` from client/package-lock.json - the root lockfile is not in the repo
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      # No database service on purpose. The suite runs against the stubs in
+      # tests/__mocks__, and the schema tests read src/db/*.sql as TEXT rather than
+      # executing it. A MySQL service here would slow every run and invite tests that
+      # depend on one ; if integration coverage is ever wanted, give it its own workflow.
+      - name: Test
+        run: npm run test
+
+  schema:
+    name: Public schema is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # server/schema/public/*.json is generated but committed, and it is only
+      # regenerated inside publish.sh / publish-rc.sh - so it silently goes stale
+      # between releases. jq is preinstalled on the runner.
+      - name: Regenerate
+        run: ./server/schema/build-public-schema.sh
+
+      - name: Fail if the committed copy differs
+        run: |
+          if ! git diff --quiet -- server/schema/public; then
+            echo "::error::server/schema/public is out of date - run ./server/schema/build-public-schema.sh and commit the result"
+            git diff -- server/schema/public
+            exit 1
+          fi
+          echo "server/schema/public matches the authoritative schema"
+
+  dependencies:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      # flags a dependency the PR adds that has a known advisory
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,23 @@ jobs:
         run: npm run lint:check
 
       - name: Test
-        run: npm run test
+        run: npm run test -- --coverage --coverage.reporter=text --coverage.reporter=json-summary
+
+      # Reported, not enforced. There is no threshold and this step cannot fail the job :
+      # a number in the summary lets a reviewer see that a PR added 300 lines of untested
+      # model code, while a gate on a 33% baseline would only teach people to raise the
+      # gate. `always()` so the figure still appears when a test failed.
+      - name: Coverage summary
+        if: always()
+        run: |
+          test -f coverage/coverage-summary.json || exit 0
+          {
+            echo "### Client coverage"
+            echo ""
+            echo "| metric | % |"
+            echo "| --- | --- |"
+            jq -r '.total | to_entries[] | select(.key | test("^(lines|statements|functions|branches)$")) | "| \(.key) | \(.value.pct)% |"' coverage/coverage-summary.json
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build
         run: npm run build
@@ -78,7 +94,20 @@ jobs:
       # executing it. A MySQL service here would slow every run and invite tests that
       # depend on one ; if integration coverage is ever wanted, give it its own workflow.
       - name: Test
-        run: npm run test
+        run: npm run test -- --coverage --coverage.reporter=text --coverage.reporter=json-summary
+
+      # see the note on the client's copy of this step - reported, never enforced
+      - name: Coverage summary
+        if: always()
+        run: |
+          test -f coverage/coverage-summary.json || exit 0
+          {
+            echo "### Server coverage"
+            echo ""
+            echo "| metric | % |"
+            echo "| --- | --- |"
+            jq -r '.total | to_entries[] | select(.key | test("^(lines|statements|functions|branches)$")) | "| \(.key) | \(.value.pct)% |"' coverage/coverage-summary.json
+          } >> "$GITHUB_STEP_SUMMARY"
 
   schema:
     name: Public schema is up to date

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: Security
 
 # Static analysis for the client and the server. This repository has three published
 # advisories against its own code (GHSA-g27f-cjvv-42rf, GHSA-56pr-p4x6-mwm6,
@@ -23,7 +23,10 @@ concurrency:
 
 jobs:
   analyze:
-    name: Analyze
+    # reads as "Security / CodeQL". GitHub separately posts its own
+    # "Code scanning results / CodeQL" check when the SARIF is uploaded - that one is
+    # emitted by the code scanning service, not by Actions, and cannot be renamed here.
+    name: CodeQL
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,11 +25,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    # A pull request from a FORK gets a read-only token, which cannot upload the SARIF
-    # result - so it is skipped there rather than left to fail a check on every PR.
-    # Nothing goes unanalysed : the push to develop and the weekly run still cover it.
-    # Drop this line if fork uploads turn out to work on this repository's plan.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Static analysis for the client and the server. This repository has three published
+# advisories against its own code (GHSA-g27f-cjvv-42rf, GHSA-56pr-p4x6-mwm6,
+# GHSA-wcmj-wqvw-6c88), which is the argument for running this on every pull request
+# rather than only on a schedule.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+  schedule:
+    # Mondays 04:17 UTC - an hour no in-process cron task of the app itself occupies
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    # A pull request from a FORK gets a read-only token, which cannot upload the SARIF
+    # result - so it is skipped there rather than left to fail a check on every PR.
+    # Nothing goes unanalysed : the push to develop and the weekly run still cover it.
+    # Drop this line if fork uploads turn out to work on this repository's plan.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      # no build step - javascript is analysed from source
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker build
+
+# Builds the image without pushing it, so "does the image still assemble" is answered at
+# review time instead of by hand during publish.sh. Path-filtered because it is the slow
+# one - it runs npm ci and a vite build inside the image - and for that reason it is not
+# a check worth requiring in branch protection.
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'Dockerfile'
+      - 'Dockerfile.base'
+      - 'client/package.json'
+      - 'client/package-lock.json'
+      - 'server/package.json'
+      - 'server/package-lock.json'
+      - 'generate-build-info.sh'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker build
+name: Docker
 
 # Builds the image without pushing it, so "does the image still assemble" is answered at
 # review time instead of by hand during publish.sh. Path-filtered because it is the slow

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,9 @@ concurrency:
 
 jobs:
   build:
-    # this is the check name a pull request shows - keep it distinct from the docker
-    # workflow's "Build image", and note that renaming it breaks any branch protection
-    # rule that requires it
-    name: Docs build
+    # reads as "Docs / Build" where the workflow name prefixes the job. Note that
+    # renaming it breaks any branch protection rule that requires it
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,7 +68,7 @@ jobs:
           path: docs/_site
 
   deploy:
-    name: Docs deploy
+    name: Deploy
     if: github.event_name != 'pull_request'
     environment:
       name: github-pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,18 @@
 name: Deploy Jekyll site to Pages
 
+# A pull request BUILDS the site but does not deploy it. docs/_data/help.yaml is the
+# single source of truth for the settings pages and is read by four tests, so a malformed
+# edit used to be discovered only after the merge, when this workflow failed on develop.
+
 on:
   push:
     branches: ["develop"]
+  pull_request:
+    branches: ["develop", "main"]
+    paths:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -11,8 +21,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  # deploys keep the single "pages" group and are never cancelled ; each PR gets its own
+  group: pages-${{ github.event.pull_request.number || 'deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -33,22 +44,28 @@ jobs:
           cache-version: 0
           working-directory: docs
       
+      # skipped on a pull request : it calls the Pages API, and a fork's token cannot.
+      # base_path is then empty, which jekyll reads as the site root - fine for a build
+      # that is only ever thrown away.
       - name: Setup Pages
         id: pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v4
-      
+
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         working-directory: docs
         env:
           JEKYLL_ENV: production
-      
+
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_site
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll site to Pages
+name: Docs
 
 # A pull request BUILDS the site but does not deploy it. docs/_data/help.yaml is the
 # single source of truth for the settings pages and is read by four tests, so a malformed
@@ -27,6 +27,10 @@ concurrency:
 
 jobs:
   build:
+    # this is the check name a pull request shows - keep it distinct from the docker
+    # workflow's "Build image", and note that renaming it breaks any branch protection
+    # rule that requires it
+    name: Docs build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,6 +69,7 @@ jobs:
           path: docs/_site
 
   deploy:
+    name: Docs deploy
     if: github.event_name != 'pull_request'
     environment:
       name: github-pages

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ ontap*.yaml
 # build artifacts (generated during build)
 build-info.json
 
+# test coverage reports (vitest writes client/coverage and server/coverage)
+coverage
+
 # local post-build scripts (may contain credentials)
 *.post.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Wizard didn't load varsFiles
+-   `target="_blank"` was stripped from links in `html` and `expression` fields, so they opened in the current tab and the form was lost (#480). `rel="noopener noreferrer"` is now forced on any link that opens a new tab
 
 ## [6.3.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Wizard didn't load varsFiles
 -   `target="_blank"` was stripped from links in `html` and `expression` fields, so they opened in the current tab and the form was lost (#480). `rel="noopener noreferrer"` is now forced on any link that opens a new tab
+-   Startup failed with `Failed to create the path for the log files` when `LOG_PATH`'s parent folder did not exist — the folder is now created recursively
 
 ## [6.3.0] - 2026-07-31
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -41,6 +41,7 @@
         "@eslint/js": "^10.0.1",
         "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-vue": "^6.0.8",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.8.1",
         "eslint-plugin-vue": "^10.10.0",
         "globals": "^17.7.0",
@@ -170,6 +171,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -1354,6 +1365,37 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -1911,6 +1953,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-walker-scope": {
@@ -3140,6 +3194,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3252,6 +3313,68 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
@@ -3675,6 +3798,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/client/package.json
+++ b/client/package.json
@@ -46,6 +46,7 @@
     "@eslint/js": "^10.0.1",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-vue": "^6.0.8",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.1",
     "eslint-plugin-vue": "^10.10.0",
     "globals": "^17.7.0",

--- a/client/src/components/AppForm.vue
+++ b/client/src/components/AppForm.vue
@@ -31,7 +31,7 @@ import { required, helpers, sameAs } from "@vuelidate/validators";
 import { useTemplateRef, nextTick, inject } from "vue";
 import { useAppStore } from "@/stores/app";
 import Helpers from '@/lib/Helpers';
-import DOMPurify from 'dompurify';
+import HtmlSanitizer from '@/lib/HtmlSanitizer';
 import TokenStorage from "@/lib/TokenStorage";
 import axios from "axios";
 import YAML from "yaml";
@@ -2395,7 +2395,7 @@ defineExpose({
                                     :class="{ 'text-body': !field.hide, 'text-grey': field.hide }">{{ typeof fieldLabels[field.name] === 'object' ? fieldLabels[field.name].value : fieldLabels[field.name] }}
                                 </label>
                                 
-                                <div v-show="!fieldOptions[field.name].viewable" v-html="DOMPurify.sanitize(v$.form[field.name].$model || '')"></div>
+                                <div v-show="!fieldOptions[field.name].viewable" v-html="HtmlSanitizer.sanitize(v$.form[field.name].$model)"></div>
                                 <!-- raw data -->
                                 <div @dblclick="setExpressionFieldViewable(field.name, false)"
                                     v-if="fieldOptions[field.name].viewable"

--- a/client/src/components/BsInputForForm.vue
+++ b/client/src/components/BsInputForForm.vue
@@ -9,7 +9,7 @@
   /******************************************************************/
 
   import { getCurrentInstance, computed } from "vue";
-  import DOMPurify from 'dompurify';
+  import HtmlSanitizer from '@/lib/HtmlSanitizer';
   import ace from 'ace-builds';
   import 'ace-builds/src-noconflict/mode-yaml'; // Load the language definition file used below
   import 'ace-builds/src-noconflict/theme-monokai'; // Load the theme definition file used below
@@ -24,7 +24,7 @@
   // MODEL
 
   const model = defineModel();
-  const sanitizedModel = computed(() => DOMPurify.sanitize(model.value || ''));
+  const sanitizedModel = computed(() => HtmlSanitizer.sanitize(model.value));
 
   // PROPS
 

--- a/client/src/lib/HtmlSanitizer.js
+++ b/client/src/lib/HtmlSanitizer.js
@@ -1,0 +1,42 @@
+/******************************************************************/
+/*                                                                */
+/*  AnsibleForms HTML sanitizer                                   */
+/*                                                                */
+/*  The single policy for form-authored HTML that reaches         */
+/*  v-html : `type: html` fields (AppForm) and `type: expression` */
+/*  fields rendered as html (BsInputForForm). Both went through   */
+/*  a bare DOMPurify.sanitize() before ; they share this module   */
+/*  so the policy cannot drift between them.                      */
+/*                                                                */
+/******************************************************************/
+
+import DOMPurify from 'dompurify';
+
+// DOMPurify 3.x does not carry `target` in its default attribute allowlist, so a link
+// written as <a href="..." target="_blank"> lost the attribute and opened in the current
+// tab - throwing away the form the user was filling in (issue #480). It is allowed back
+// here, and nothing else is widened : `onclick` and every other event handler is still
+// refused, and a javascript: href is still dropped even on a link that carries a target.
+export const ADD_ATTR = ['target'];
+
+// A target other than _self opens a new browsing context, and the page that lands there
+// can steer its opener through window.opener unless rel says otherwise. Browsers imply
+// noopener for target="_blank" these days but not for a named target, and the form author
+// cannot be relied on to write the rel - so it is forced on rather than expected.
+export function forceSafeRel(node) {
+  if (typeof node?.getAttribute !== 'function') return; // text/comment nodes
+  const target = node.getAttribute('target');
+  if (!target || target === '_self') return;
+  const rel = new Set((node.getAttribute('rel') || '').split(/\s+/).filter(Boolean));
+  rel.add('noopener');
+  rel.add('noreferrer');
+  node.setAttribute('rel', [...rel].join(' '));
+}
+
+DOMPurify.addHook('afterSanitizeAttributes', forceSafeRel);
+
+export function sanitize(html) {
+  return DOMPurify.sanitize(html || '', { ADD_ATTR });
+}
+
+export default { sanitize, forceSafeRel, ADD_ATTR };

--- a/client/tests/html-sanitizer.test.js
+++ b/client/tests/html-sanitizer.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import HtmlSanitizer, { ADD_ATTR, forceSafeRel, sanitize } from '../src/lib/HtmlSanitizer.js';
+
+// ─── Link targets in form HTML (issue #480) ───
+//
+// `target` is NOT in DOMPurify 3.x's default attribute allowlist, so a bare
+// DOMPurify.sanitize() dropped it and a link written with target="_blank" navigated in
+// the current tab, discarding the form the user was filling in. `ADD_ATTR` is what puts
+// it back, so it is asserted directly.
+//
+// It is asserted as CONFIGURATION rather than as sanitize() output on purpose : these
+// tests run in happy-dom, which is not a faithful enough DOM for DOMPurify to be pinned
+// by its output. Measured here - happy-dom keeps `target` even with the default config
+// (so an output assertion would pass on the unfixed code, a false green) and strips
+// block elements such as <p> and <div> that every real browser keeps. The output
+// behaviour was verified by hand against Chromium instead : with the default config
+// Chromium yields `<a href="..." rel="noopener noreferrer">`, with ADD_ATTR ['target']
+// it yields `<a href="..." target="_blank" rel="noopener noreferrer">`, and a
+// javascript: href is dropped either way.
+
+describe('HtmlSanitizer configuration', () => {
+  it('allows target back into the attribute allowlist', () => {
+    expect(ADD_ATTR).toContain('target');
+  });
+
+  it('widens nothing beyond target', () => {
+    expect(ADD_ATTR).toEqual(['target']);
+  });
+
+  it('exposes sanitize on the default export', () => {
+    expect(typeof HtmlSanitizer.sanitize).toBe('function');
+    expect(typeof sanitize('')).toBe('string');
+  });
+
+  it('treats a null or undefined value as empty', () => {
+    expect(sanitize(null)).toBe('');
+    expect(sanitize(undefined)).toBe('');
+  });
+});
+
+// ─── rel is forced, not trusted to the form author ───
+//
+// forceSafeRel is the `afterSanitizeAttributes` hook, kept pure so it can be pinned
+// without a DOM : it only ever reads and writes attributes through the node interface.
+
+function fakeNode(attributes = {}) {
+  const attrs = { ...attributes };
+  return {
+    attrs,
+    getAttribute: (name) => (name in attrs ? attrs[name] : null),
+    setAttribute: (name, value) => { attrs[name] = value; },
+  };
+}
+
+describe('forceSafeRel', () => {
+  it('forces noopener and noreferrer on target="_blank"', () => {
+    const node = fakeNode({ href: 'https://example.com', target: '_blank' });
+    forceSafeRel(node);
+    expect(node.attrs.rel.split(' ').sort()).toEqual(['noopener', 'noreferrer']);
+  });
+
+  it('forces them on a named target too, which browsers do not imply', () => {
+    const node = fakeNode({ target: 'someWindow' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toContain('noopener');
+    expect(node.attrs.rel).toContain('noreferrer');
+  });
+
+  it('keeps the rel tokens the author already wrote', () => {
+    const node = fakeNode({ target: '_blank', rel: 'nofollow' });
+    forceSafeRel(node);
+    const rel = node.attrs.rel.split(' ');
+    expect(rel).toContain('nofollow');
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  it('does not duplicate a token that is already present', () => {
+    const node = fakeNode({ target: '_blank', rel: 'noopener  noopener noreferrer' });
+    forceSafeRel(node);
+    expect(node.attrs.rel.split(' ').filter((r) => r === 'noopener')).toHaveLength(1);
+  });
+
+  it('leaves a node without a target untouched', () => {
+    const node = fakeNode({ href: 'https://example.com' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toBeUndefined();
+  });
+
+  it('leaves target="_self" untouched - it opens no new context', () => {
+    const node = fakeNode({ target: '_self' });
+    forceSafeRel(node);
+    expect(node.attrs.rel).toBeUndefined();
+  });
+
+  it('ignores a node with no attribute interface (text and comment nodes)', () => {
+    expect(() => forceSafeRel({})).not.toThrow();
+    expect(() => forceSafeRel(null)).not.toThrow();
+  });
+});

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -2724,7 +2724,10 @@
                       required: true
                       default: "2026-01"                       
               - name: html
-                description: An HTML field
+                description: |
+                  An HTML field.
+                  The html is sanitized before it is rendered : `<script>`, event handlers (`onclick`, `onerror`, ...) and `javascript:` links are always removed.
+                  A link may carry `target="_blank"` to open in a new tab ; `rel="noopener noreferrer"` is added automatically.
                 version: 4.0.9
                 examples:
                 - name: Alert
@@ -2743,6 +2746,12 @@
                       type: html
                       expression: | 
                         '<h3 class="title is-3">Your own title</h3>'          
+                - name: Link opening in a new tab
+                  code: |
+                    - type: html
+                      name: documentation
+                      expression: |
+                        '<a href="https://ansibleforms.com/" target="_blank">Read the documentation</a>'
               - name: file
                 description: A file upload field, the file is uploaded prior to the job start and the extravars will contain the uploaded file info.
                 version: 4.0.16
@@ -3901,6 +3910,8 @@
             short: Renders text as html
             description: |
               If an expression value has html tags (for example <b></b>), it will render the value as such.
+              The html is sanitized before it is rendered : `<script>`, event handlers (`onclick`, `onerror`, ...) and `javascript:` links are always removed.
+              A link may carry `target="_blank"` to open in a new tab ; `rel="noopener noreferrer"` is added automatically.
             examples:
             - name: Show bold in an expression
               code: |

--- a/server/config/log.config.js
+++ b/server/config/log.config.js
@@ -23,8 +23,12 @@ var log_config = {
 };
 if ( !fs.existsSync( log_config.path ) ) {
   try{
-    // Create the directory if it does not exist
-    fs.mkdirSync( log_config.path );
+    // Create the directory if it does not exist.
+    // `recursive` matters : the default LOG_PATH is ./persistent/logs and persistent/ is
+    // gitignored, so on a fresh clone the parent does not exist either and a plain mkdir
+    // fails with ENOENT - taking 22 test suites and `npm run dev` down with it. That is
+    // what "server/persistent/ must exist" was a manual workaround for.
+    fs.mkdirSync( log_config.path, { recursive: true } );
   }catch(err){
     throw new Error("Failed to create the path for the log files", { cause: err })
   }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -55,6 +55,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "~10.8.1",
         "globals": "^17.9.0",
         "nodemon": "~3.1.14",
@@ -301,6 +302,66 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -567,12 +628,33 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@js-joda/core": {
       "version": "6.0.1",
@@ -1023,6 +1105,37 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -1237,6 +1350,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/async": {
@@ -2904,6 +3029,13 @@
         "url": "https://github.com/sponsors/EvanHahn"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3232,6 +3364,68 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -3245,6 +3439,13 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-bigint": {
@@ -3789,6 +3990,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/server/package.json
+++ b/server/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "~10.8.1",
     "globals": "^17.9.0",
     "nodemon": "~3.1.14",

--- a/server/tests/retention-zero.test.mjs
+++ b/server/tests/retention-zero.test.mjs
@@ -11,12 +11,21 @@
 // 'restore points never' for 0, with the note "0 deletes nothing, for every one of these" -
 // so the code was what was wrong, not the note. That claim is asserted here too: a page
 // whose premise is never claiming an unearned fact must not be the thing that is lying.
-import { test, describe, expect, vi, beforeEach } from "vitest";
+import { test, describe, expect, vi, beforeEach, afterEach } from "vitest";
 
 process.env.DB_HOST ||= "127.0.0.1";
 process.env.DB_PORT ||= "3306";
 process.env.DB_USER ||= "test";
 process.env.DB_PASSWORD ||= "test";
+
+// The fixtures below are dated relative to a fixed day, but removeOld measures them
+// against the real clock - so they aged with the calendar and the file went red on
+// 2026-08-01, when the 60-day-old snapshot became 61 real days old and started being
+// pruned. The clock is frozen instead, and the timezone pinned with it : removeOld
+// parses the date part as LOCAL midnight, so under UTC+13 or further the same stamp
+// is a day older than it reads. Both have to be set before the model is imported.
+process.env.TZ = "UTC";
+const NOW = Date.UTC(2026, 6, 31, 12);
 
 // a backup folder holding snapshots of various ages
 const removed = [];
@@ -40,14 +49,21 @@ const Form = (await import("../src/models/form.model.js")).default;
 
 // 'YYYYMMDDHHmmssSSS' - 17 digits, which is what removeOld filters on
 function stamp(daysAgo) {
-  const d = new Date(Date.UTC(2026, 6, 31) - daysAgo * 86400000);
+  const d = new Date(NOW - daysAgo * 86400000);
   const p = (n, w = 2) => String(n).padStart(w, "0");
   return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}120000000`;
 }
 
 beforeEach(() => {
+  // only Date is faked - the model uses no timers, and faking those would hang vitest
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
   removed.length = 0;
   entries = [90, 61, 60, 30, 1, 0].map((n) => `config.yaml.bak.${stamp(n)}`);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("OLD_BACKUP_DAYS", () => {


### PR DESCRIPTION
> **Stacked on #484.** Until that merges, the diff shows its commits too.

Nothing measures coverage today, so *"this PR adds 300 lines of untested model code"* is invisible at review time. Both jobs now print a table into the run summary.

Measured baseline:

| | lines | statements | functions | branches |
|---|---|---|---|---|
| **server** | 32.83% | 33.19% | 42.97% | 33.1% |
| **client** | 30.42% | 29.02% | 25% | 20.41% |

## Reported, never enforced

No threshold, and the step **cannot fail the job**. A gate on a 33% baseline teaches people to raise the gate rather than to write tests; the number is there to be looked at by someone already reading the diff.

It runs under `if: always()` so the figure still appears when a test failed — which is exactly when *"was that path covered at all?"* comes up.

## Also in here

- **`@vitest/coverage-v8`** added as a dev dependency to both packages — `vitest run --coverage` prompts to install it interactively otherwise, which hangs a CI run rather than failing it.
- **`coverage` added to `.gitignore`.** vitest writes `client/coverage` and `server/coverage` and neither was ignored, so the first person to run coverage locally would have committed a few hundred files. That's a bug this PR would have introduced if left out.

## Verified

I ran the exact command and the exact `jq` expression the workflow uses against both suites — the table above is its real output, not a mock-up.

## Worth knowing

Those numbers look low, but they're honest rather than alarming: much of both trees is Vue templates and Express wiring that unit tests don't reach. The 852 server tests are concentrated on the models and guards, which is the right place for them. I'd read the number as a **trend line**, not a target — if it drops sharply on a PR, that's the signal worth acting on.
