### PR TITLE
ci: publish from actions, and simplify the release flow

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -5,9 +5,6 @@ on:
       versionName:
         description: 'Name of version  (ie 5.5.0)'
         required: true
-      versionCode:
-        description: 'Version number (50500)'
-        required: true
 permissions:
   contents: write
   pull-requests: write
@@ -28,8 +25,12 @@ jobs:
       run: |
        git config user.name "GitHub Actions"
        git config user.email noreply@github.com
-    - name: Change version number and name
-      run: printf 'ext.version_code = ${{ github.event.inputs.versionCode }}\next.version_name = "${{ github.event.inputs.versionName }}"\n' > app_versions.gradle
+    # `npm version` rather than writing the file by hand : it validates the semver, so a
+    # typo like "6.4" fails here instead of producing a bad tag and a bad image name, and
+    # it keeps package-lock.json's copy of the version in step.
+    - name: Change version number
+      working-directory: server
+      run: npm version "${{ github.event.inputs.versionName }}" --no-git-tag-version --allow-same-version
     - name: Update Changelog
       run: |
         VERSION="${{ github.event.inputs.versionName }}"
@@ -38,7 +39,7 @@ jobs:
     - name: Commit changelog and manifest files
       id: make-commit
       run: |
-        git add app_versions.gradle
+        git add server/package.json server/package-lock.json
         git add CHANGELOG.md
         git commit --message "Prepare release ${{ github.event.inputs.versionName }}"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -2,9 +2,12 @@ name: Create Release Branch
 on:
   workflow_dispatch:
     inputs:
-      versionName:
-        description: 'Name of version  (ie 5.5.0)'
+      bump:
+        description: 'Which part of the version to increase'
         required: true
+        type: choice
+        options: [patch, minor, major]
+        default: patch
 permissions:
   contents: write
   pull-requests: write
@@ -17,23 +20,31 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v6
       with:
+        # ALWAYS develop, never the branch picked in "Use workflow from". That dropdown
+        # defaults to main, and a release cut from main is a release of the last release -
+        # silently, with no error anywhere.
+        ref: develop
         fetch-depth: 0
         token: ${{ secrets.PAT_TOKEN }}
-    - name: Create release branch
-      run: git checkout -b release/v${{ github.event.inputs.versionName }}
     - name: Initialize mandatory git config
       run: |
        git config user.name "GitHub Actions"
        git config user.email noreply@github.com
-    # `npm version` rather than writing the file by hand : it validates the semver, so a
-    # typo like "6.4" fails here instead of producing a bad tag and a bad image name, and
-    # it keeps package-lock.json's copy of the version in step.
+    # A bump type rather than a typed-out version : npm computes the number, so there is
+    # no "what comes after 6.3.0" and no typo to carry into a tag and an image name.
     - name: Change version number
+      id: bump
       working-directory: server
-      run: npm version "${{ github.event.inputs.versionName }}" --no-git-tag-version --allow-same-version
+      run: |
+        raw=$(npm version "${{ inputs.bump }}" --no-git-tag-version)
+        version="${raw#v}"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "Releasing $version"
+    - name: Create release branch
+      run: git checkout -b release/v${{ steps.bump.outputs.version }}
     - name: Update Changelog
       run: |
-        VERSION="${{ github.event.inputs.versionName }}"
+        VERSION="${{ steps.bump.outputs.version }}"
         DATE=$(date +%Y-%m-%d)
         sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
     - name: Commit changelog and manifest files
@@ -41,18 +52,18 @@ jobs:
       run: |
         git add server/package.json server/package-lock.json
         git add CHANGELOG.md
-        git commit --message "Prepare release ${{ github.event.inputs.versionName }}"
+        git commit --message "Prepare release ${{ steps.bump.outputs.version }}"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
     - name: Push new branch
-      run: git push origin release/v${{ github.event.inputs.versionName }}
+      run: git push origin release/v${{ steps.bump.outputs.version }}
     - name: Create pull request into main
       env:
         GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
         gh pr create \
           --base main \
-          --head release/v${{ github.event.inputs.versionName }} \
-          --title "v${{ github.event.inputs.versionName }} into main" \
+          --head release/v${{ steps.bump.outputs.version }} \
+          --title "v${{ steps.bump.outputs.version }} into main" \
           --body "This PR was created by the release workflow. Version commit: ${{ steps.make-commit.outputs.commit }}"
     - name: Create pull request to develop
       env:
@@ -60,6 +71,6 @@ jobs:
       run: |
         gh pr create \
           --base develop \
-          --head release/v${{ github.event.inputs.versionName }} \
-          --title "v${{ github.event.inputs.versionName }} into develop" \
+          --head release/v${{ steps.bump.outputs.version }} \
+          --title "v${{ steps.bump.outputs.version }} into develop" \
           --body "This PR was created by the release workflow. Version commit: ${{ steps.make-commit.outputs.commit }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,10 @@ jobs:
           version=$(jq -r .version server/package.json)
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          # short, not github.sha : generate-build-info.sh writes GIT_SHA verbatim into
+          # build-info.json, and publish.sh has always passed `git rev-parse --short`.
+          # The full 40 characters would change what the About dialog shows.
+          echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           echo "Publishing $version"
 
       # a release must describe the version in the manifest, or the image and the git tag
@@ -87,7 +91,7 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.list }}
           build-args: |
-            GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.v.outputs.sha_short }}
             BUILD_TIME=${{ steps.v.outputs.build_time }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,105 @@
+name: Publish
+
+# Builds and pushes the application image from CI instead of from a maintainer's laptop.
+#
+# publish.sh and publish-rc.sh still work and are left in place ; this is the same
+# sequence with three differences that matter :
+#
+#   * the image is built from the commit the release points at, not from whatever is in
+#     someone's working tree - "it built on my machine" stops being part of a release
+#   * the credentials are a repository secret with a scoped token rather than a personal
+#     docker login on a workstation
+#   * it does not commit anything. publish.sh regenerates server/schema/public and pushes
+#     the result mid-release ; CI already fails a pull request whose committed copy is
+#     stale, so by the time a release exists that file is correct and a publish step has
+#     no business writing to the repository.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      rc:
+        description: 'Publish as a release candidate (<version>-rc and latest-rc)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and push
+    runs-on: ubuntu-latest
+    environment: dockerhub
+    steps:
+      - uses: actions/checkout@v6
+
+      # server/package.json is the single source of truth for the version - the same file
+      # tag_release.yml reads to name the tag, so the image and the tag cannot disagree
+      - name: Read the version
+        id: v
+        run: |
+          version=$(jq -r .version server/package.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "Publishing $version"
+
+      # a release must describe the version in the manifest, or the image and the git tag
+      # would name different things - the failure this whole arrangement exists to prevent
+      - name: Check the release tag matches the manifest
+        if: github.event_name == 'release'
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          version="${{ steps.v.outputs.version }}"
+          if [ "${tag#v}" != "$version" ]; then
+            echo "::error::release tag '$tag' does not match server/package.json version '$version'"
+            exit 1
+          fi
+          echo "release tag and manifest agree on $version"
+
+      - name: Work out the tags
+        id: tags
+        run: |
+          repo="${{ vars.DOCKERHUB_REPOSITORY || 'ansibleguy/ansibleforms' }}"
+          version="${{ steps.v.outputs.version }}"
+          if [ "${{ inputs.rc }}" = "true" ]; then
+            printf 'list=%s:%s-rc,%s:latest-rc\n' "$repo" "$version" "$repo" >> "$GITHUB_OUTPUT"
+          else
+            printf 'list=%s:%s,%s:latest\n' "$repo" "$version" "$repo" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.list }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.v.outputs.build_time }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "### Published"
+            echo ""
+            echo '```'
+            echo "${{ steps.tags.outputs.list }}" | tr ',' '\n'
+            echo '```'
+            echo ""
+            echo "from \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ name: Publish
 #     the result mid-release ; CI already fails a pull request whose committed copy is
 #     stale, so by the time a release exists that file is correct and a publish step has
 #     no business writing to the repository.
+#
+# It pushes to GHCR always and to Docker Hub when the secret is there. Docker Hub stays
+# the canonical channel - docs/installation.md tells people to pull ansibleguy/ansibleforms
+# and every deployment in the wild points at it - so GHCR is a mirror beside it, not a
+# replacement. To drop Docker Hub one day, delete its login step and the two tags.
 
 on:
   release:
@@ -26,6 +31,7 @@ on:
 
 permissions:
   contents: read
+  packages: write   # GHCR, through the automatic GITHUB_TOKEN - no secret needed
 
 concurrency:
   group: publish
@@ -66,20 +72,58 @@ jobs:
           fi
           echo "release tag and manifest agree on $version"
 
+      # Docker Hub is optional, GHCR is not. GHCR needs no secret at all - the automatic
+      # GITHUB_TOKEN authenticates it - so the workflow publishes something useful before
+      # anyone has created a Docker Hub token, and the first run proves itself. When the
+      # secret is absent the Docker Hub login and its tags are simply left out rather than
+      # failing the job.
+      - name: Is Docker Hub configured?
+        id: hub
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "Docker Hub credentials present - publishing there as well"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOCKERHUB_TOKEN is not set - publishing to GHCR only"
+          fi
+
       - name: Work out the tags
         id: tags
         run: |
-          repo="${{ vars.DOCKERHUB_REPOSITORY || 'ansibleguy/ansibleforms' }}"
           version="${{ steps.v.outputs.version }}"
+          # github.repository is already lowercase here ; GHCR rejects anything else
+          ghcr="ghcr.io/${{ github.repository }}"
+          hub="${{ vars.DOCKERHUB_REPOSITORY || 'ansibleguy/ansibleforms' }}"
+
           if [ "${{ inputs.rc }}" = "true" ]; then
-            printf 'list=%s:%s-rc,%s:latest-rc\n' "$repo" "$version" "$repo" >> "$GITHUB_OUTPUT"
+            primary="$version-rc"; moving="latest-rc"
           else
-            printf 'list=%s:%s,%s:latest\n' "$repo" "$version" "$repo" >> "$GITHUB_OUTPUT"
+            primary="$version"; moving="latest"
           fi
+
+          tags="$ghcr:$primary,$ghcr:$moving"
+          if [ "${{ steps.hub.outputs.enabled }}" = "true" ]; then
+            tags="$tags,$hub:$primary,$hub:$moving"
+          fi
+          echo "list=$tags" >> "$GITHUB_OUTPUT"
+          echo "$tags" | tr ',' '\n'
 
       - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v3
+      # no secret : GITHUB_TOKEN carries packages:write, declared on the job above
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: steps.hub.outputs.enabled == 'true'
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release Branch
+name: Release
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   createrelease:
+    name: Prepare
     runs-on: ubuntu-latest
 
     steps:
@@ -40,37 +41,42 @@ jobs:
         version="${raw#v}"
         echo "version=$version" >> "$GITHUB_OUTPUT"
         echo "Releasing $version"
-    - name: Create release branch
-      run: git checkout -b release/v${{ steps.bump.outputs.version }}
     - name: Update Changelog
       run: |
         VERSION="${{ steps.bump.outputs.version }}"
         DATE=$(date +%Y-%m-%d)
         sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
-    - name: Commit changelog and manifest files
+    # Straight onto develop, with no release branch in between. The last four release
+    # branches took no commits after being cut - they held one "Prepare release" commit,
+    # produced two pull requests and were merged twice - so the branch bought nothing and
+    # the back-merge was a rubber stamp. Committing here instead means develop cannot
+    # drift from main, and a hotfix branch can still be cut from the tag later.
+    - name: Commit to develop
       id: make-commit
       run: |
-        git add server/package.json server/package-lock.json
-        git add CHANGELOG.md
+        git add server/package.json server/package-lock.json CHANGELOG.md
         git commit --message "Prepare release ${{ steps.bump.outputs.version }}"
+        git push origin develop
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-    - name: Push new branch
-      run: git push origin release/v${{ steps.bump.outputs.version }}
-    - name: Create pull request into main
+    # One pull request, not two. Reused if a develop -> main one is already open, because
+    # gh pr create fails rather than no-ops in that case.
+    - name: Open the release pull request
       env:
         GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
-        gh pr create \
-          --base main \
-          --head release/v${{ steps.bump.outputs.version }} \
-          --title "v${{ steps.bump.outputs.version }} into main" \
-          --body "This PR was created by the release workflow. Version commit: ${{ steps.make-commit.outputs.commit }}"
-    - name: Create pull request to develop
-      env:
-        GH_TOKEN: ${{ secrets.PAT_TOKEN }}
-      run: |
-        gh pr create \
-          --base develop \
-          --head release/v${{ steps.bump.outputs.version }} \
-          --title "v${{ steps.bump.outputs.version }} into develop" \
-          --body "This PR was created by the release workflow. Version commit: ${{ steps.make-commit.outputs.commit }}"
+        version="${{ steps.bump.outputs.version }}"
+        body=$(printf '%s\n' \
+          "Release **$version**, prepared by the release workflow." \
+          "" \
+          "Version commit: ${{ steps.make-commit.outputs.commit }}" \
+          "" \
+          "Merging this runs \`tag_release\`, which creates the GitHub release, which in" \
+          "turn runs \`publish\` and pushes the images. Nothing else is needed afterwards -" \
+          "the version bump is already on develop.")
+        existing=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number // empty')
+        if [ -n "$existing" ]; then
+          gh pr edit "$existing" --title "Release $version" --body "$body"
+          echo "updated existing pull request #$existing"
+        else
+          gh pr create --base main --head develop --title "Release $version" --body "$body"
+        fi

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -18,7 +18,12 @@ jobs:
                   git config user.email noreply@github.com
             - name: Setup release information
               run: |
-                  versionName=$(sed '2q;d' app_versions.gradle | cut -d "=" -f2 | xargs)
+                  # server/package.json is the single source of truth for the version : it
+                  # is what the running app reports through /api/v2/version and what
+                  # publish.sh tags the image with. This step used to read a separate
+                  # app_versions.gradle, which nothing kept in step with it - so the git
+                  # tag and the docker tag could describe different releases.
+                  versionName=$(jq -r .version server/package.json)
                   echo "VERSION_NAME=$versionName" >> $GITHUB_ENV
             - name: Extract release notes
               id: extract_release_notes

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -28,8 +28,16 @@ jobs:
             - name: Extract release notes
               id: extract_release_notes
               run: |
-                # Extract content between first two version headers in CHANGELOG.md
-                NOTES=$(awk '/^## \[/{if(n++)exit}n' CHANGELOG.md | tail -n +2)
+                # The section for THIS version, not "between the first two headings".
+                # The release workflow inserts `## [x.y.z]` directly beneath
+                # `## [Unreleased]`, which leaves Unreleased empty - so the old expression
+                # read that empty section and every release got blank notes. Measured: the
+                # 6.2.1 release has 0 characters of body.
+                NOTES=$(awk -v ver="## [$VERSION_NAME]" '
+                  index($0, ver) == 1 { inside = 1; next }
+                  inside && /^## \[/ { exit }
+                  inside { print }
+                ' CHANGELOG.md)
                 echo "release_notes<<EOF" >> $GITHUB_OUTPUT
                 echo "$NOTES" >> $GITHUB_OUTPUT
                 echo "EOF" >> $GITHUB_OUTPUT

--- a/app_versions.gradle
+++ b/app_versions.gradle
@@ -1,2 +1,0 @@
-ext.version_code = 060300
-ext.version_name = "6.3.0"


### PR DESCRIPTION
> **Stacked on #485** (the version single-source PR), because both touch the release workflows. Until that merges the diff shows its commit too.

Two halves of the same thing: **publishing moves off a laptop into CI, and the release ceremony collapses to one dispatch and one merge.**

Five commits, each droppable on its own.

## Part 1 — publish from Actions

The production image is built and pushed from a maintainer's workstation. CI proves the image *builds* (#484); nothing proves the image that **shipped** came from the reviewed commit.

**It needs no secrets to work.** GHCR authenticates with the automatic `GITHUB_TOKEN`. Docker Hub is published to as well *when* its token exists, and skipped cleanly when it doesn't.

### ⚠️ Read this before the first run

**A new GHCR package is created private, even on a public repo.** After the first run you'll need **Packages → ansibleforms → Package settings → change visibility → Public**, or nobody can pull it anonymously. This catches people out reliably — the workflow reports a successful push and users still get `denied`.

### Registries

| | | |
|---|---|---|
| **Docker Hub** — `ansibleguy/ansibleforms` | canonical | when `DOCKERHUB_TOKEN` is set |
| **GHCR** — `ghcr.io/ansibleguy76/ansibleforms` | mirror | always |

Docker Hub stays canonical rather than being replaced: `docs/installation.md` tells people to `docker pull ansibleguy/ansibleforms:latest` (lines 182, 187, 395) and every deployment in the wild points at it. Tags verified across all four combinations of rc/release × hub present/absent; the Docker Hub ones are **byte-identical** to what `publish.sh` and `publish-rc.sh` push today.

### Three differences from `publish.sh`

1. **Builds from the release's commit**, not a working tree.
2. **Scoped credentials**, not a personal `docker login`.
3. **Commits nothing.** `publish.sh` regenerates `server/schema/public` and `git push`es it mid-release; #484's `schema` job already fails any PR whose copy is stale, so by release time it's correct. Hence `contents: read`.

It also refuses to publish when the release tag and `server/package.json` disagree — the failure #485 prevents, asserted again so a divergence can't ship.

## Part 2 — the release flow

Two silent ways to get a release wrong, and a lot of ceremony that bought nothing.

**Silent failure one:** the workflow branched from whatever "Use workflow from" was set to, and that dropdown **defaults to `main`**. Cutting a release from main produces a release of the previous release, with no error anywhere. It now checks out `develop` explicitly and ignores the dropdown.

**Silent failure two:** the version was free text, so the operator had to know what came after 6.3.0 and type it correctly. It's a `patch` / `minor` / `major` dropdown now and npm computes the number — verified `6.3.1` / `6.4.0` / `7.0.0`.

**The ceremony.** I checked what the release branch actually buys:

```
release/v6.2.1 : 0 commits not on main
release/v6.2.0 : 0
release/v6.1.5 : 0
release/v6.1.4 : 0
```

The last four each took **zero** commits after being cut. Each held one `Prepare release` commit, produced two PRs and was merged twice. Nothing was ever stabilised or hotfixed on one. And the back-merge always landed — `main` has no commit `develop` lacks — so the second PR ran every time and decided nothing. A step people click through without reading is not a safety measure.

So the bump commit goes **straight onto develop** and a single `develop → main` PR is opened:

```
Actions → Release → [patch | minor | major]
        ↓
  bumps version + changelog, commits to develop, opens ONE PR
        ↓  review, merge
  tag_release → GitHub release → publish → images
```

One dispatch, one merge. Develop can't drift from main, because the bump was made there. Everything downstream is unchanged.

Renamed to `release.yml` / **Release** / **Prepare**, since it no longer creates a branch. If a `develop → main` PR is already open it's updated rather than recreated — `gh pr create` fails in that case rather than no-opping.

**What's given up:** a branch to stabilise on while develop moves. A real pattern, just not one used here in four releases — and a hotfix can still start from the tag: `git checkout -b hotfix/6.4.1 6.4.0`. If you'd rather keep release branches, drop the last commit; the hardening in the one before it stands on its own.

## Why the chain fires at all

`tag_release.yml` creates the release with `secrets.PAT_TOKEN`, not `GITHUB_TOKEN`. **Events raised by `GITHUB_TOKEN` don't trigger further workflows** — that's GitHub's recursion guard. Because you already use a PAT, `release: published` reaches `publish.yml`.

If anyone ever "tidies" that to `GITHUB_TOKEN`, the release is still created and **publishing silently stops**. Worth a comment in that file one day.

## Setup — all optional

| | |
|---|---|
| `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` | secrets. Without them it publishes to GHCR only and logs a notice. Use an **access token**, not the password |
| `DOCKERHUB_REPOSITORY` | variable, overrides `ansibleguy/ansibleforms` for testing in your own namespace |

They live in an environment called `dockerhub`, which can carry required reviewers. Delete the `environment:` line for plain repository secrets.

## Verified, and not

**Verified:** all YAML parses; every `run` block passes `bash -n` with expressions stripped; tag strings for all four combinations; all three bump types resolve correctly; the changelog `sed` produces the right heading; the PR-body construction renders; the image builds from this tree (#484's Docker job, plus a local build in #487); and the short-SHA expression yields `a2d1f6d`, byte-identical to `git rev-parse --short HEAD`.

That last one was a bug caught while writing this up — I'd passed `github.sha`, the full 40 characters, where `publish.sh` passes a short SHA, and `generate-build-info.sh` writes `GIT_SHA` verbatim, so the About dialog would have started showing a different shape of string.

**Not verified:** the push, and a real release run. `workflow_dispatch` only appears once a workflow is on the **default branch**, so the first opportunity is after this reaches `main`. Smoke-test publishing with `rc` checked — that publishes to `-rc` tags nothing depends on.

## The scripts stay

`publish.sh` and `publish-rc.sh` are untouched — break-glass. I'd retire them once this has run, since a release process depending on two paths staying in step is the problem being fixed. `publish-base.sh` still runs by hand; #487 pins the base by digest, so automating it is a separate decision.
