### PR TITLE
ci: let dependabot propose dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+# target-branch is develop on every entry : the default would be main, and this project
+# merges into develop.
+
+updates:
+  - package-ecosystem: npm
+    directory: /client
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      client-dev:
+        dependency-type: development
+
+  - package-ecosystem: npm
+    directory: /server
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      server-dev:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ['*']


### PR DESCRIPTION
> **Merge this after #484**, not before. See below.

Weekly dependency updates for the two npm trees and for the actions themselves.

| ecosystem | directory | target | cadence | limit |
|---|---|---|---|---|
| npm | `/client` | develop | weekly | 5 |
| npm | `/server` | develop | weekly | 5 |
| github-actions | `/` | develop | weekly | default |

**`target-branch: develop` matters more than it looks.** The default is the repository's *default* branch — `main` here — so without it dependabot would open every upgrade against released code, which is the one branch that shouldn't be getting dependency bumps.

Development dependencies are grouped, so a vitest or eslint bump arrives as one PR rather than six.

## Sequencing

This was originally inside #484 and has been split out, because it's a different kind of decision: #484 answers *"does this PR pass?"*, this one answers *"who proposes upgrades, and how often?"*. You might want one and not the other, and bundling them meant you couldn't choose.

**It's worth merging after #484, not before.** Until checks run on pull requests, each of these arrives with nothing verifying it — and roughly ten dependency bumps to test by hand is worse than not having them at all. With CI in place, every bump gets lint, tests and a build automatically, which is the entire point.

## Expect a burst

The first week will be busier than the steady state — both trees are a release behind on several dev dependencies. `open-pull-requests-limit: 5` per ecosystem caps it, but if it's still noisy, `interval: monthly` is a one-word change and grouping can be widened to cover production dependencies too.
