### PR TITLE
Re-apply the config seed when the file changes (CONFIG_SEED_RELOAD_SECONDS, /config-seed/apply, SIGHUP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `GIT_PUSH_COMMAND` env var added, to customize the command used when pushing git repositories
+-   The config seed is re-applied when the file changes (`CONFIG_SEED_RELOAD_SECONDS`, 60s by default), so a seed edited in git reaches a running instance without restarting it. `POST /api/v2/config-seed/apply` and `SIGHUP` force an apply immediately. A failed reload is never fatal: the configuration already in force is kept and the Status page reports it. See `docs/seed.md`
 
 ### Fixed
 

--- a/client/src/locales/de.js
+++ b/client/src/locales/de.js
@@ -122,6 +122,7 @@ export default {
       settings_env_update: "Umgebungseinstellungen aktualisiert",
       config_env_update: "Umgebungseinstellungen gespeichert",
       seed_apply: "Konfigurations-Seed angewendet",
+      config_seed_apply_create: "Erneutes Anwenden des Konfigurations-Seeds angefordert",
       backup_restore_env_create: "Umgebungsdatei aus einem Backup wiederhergestellt",
       backup_restoreEnv: "Umgebungsdatei aus einem Backup wiederhergestellt",
       config_save: "Konfiguration gespeichert",

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -122,6 +122,7 @@ export default {
       settings_env_update: "Environment settings updated",
       config_env_update: "Environment settings saved",
       seed_apply: "Config seed applied",
+      config_seed_apply_create: "Config seed re-apply requested",
       backup_restore_env_create: "Environment file restored from a backup",
       backup_restoreEnv: "Environment file restored from a backup",
       config_save: "Configuration saved",

--- a/client/src/locales/es.js
+++ b/client/src/locales/es.js
@@ -122,6 +122,7 @@ export default {
       settings_env_update: "Ajustes de entorno actualizados",
       config_env_update: "Ajustes de entorno guardados",
       seed_apply: "Seed de configuración aplicado",
+      config_seed_apply_create: "Reaplicación del seed de configuración solicitada",
       backup_restore_env_create: "Archivo de entorno restaurado desde una copia",
       backup_restoreEnv: "Archivo de entorno restaurado desde una copia",
       config_save: "Configuración guardada",

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -122,6 +122,7 @@ export default {
       settings_env_update: "Paramètres d'environnement modifiés",
       config_env_update: "Paramètres d'environnement enregistrés",
       seed_apply: "Seed de configuration appliqué",
+      config_seed_apply_create: "Réapplication du seed de configuration demandée",
       backup_restore_env_create: "Fichier d'environnement restauré depuis une sauvegarde",
       backup_restoreEnv: "Fichier d'environnement restauré depuis une sauvegarde",
       config_save: "Configuration enregistrée",

--- a/client/src/locales/it.js
+++ b/client/src/locales/it.js
@@ -122,6 +122,7 @@ export default {
       settings_env_update: "Impostazioni ambiente aggiornate",
       config_env_update: "Impostazioni ambiente salvate",
       seed_apply: "Seed di configurazione applicato",
+      config_seed_apply_create: "Riapplicazione del seed di configurazione richiesta",
       backup_restore_env_create: "File di ambiente ripristinato da un backup",
       backup_restoreEnv: "File di ambiente ripristinato da un backup",
       config_save: "Configurazione salvata",

--- a/client/src/locales/nl.js
+++ b/client/src/locales/nl.js
@@ -122,6 +122,7 @@ export default {
       settings_env_update: "Omgevingsinstellingen bijgewerkt",
       config_env_update: "Omgevingsinstellingen opgeslagen",
       seed_apply: "Configuratie-seed toegepast",
+      config_seed_apply_create: "Opnieuw toepassen van de configuratie-seed aangevraagd",
       backup_restore_env_create: "Omgevingsbestand hersteld uit een back-up",
       backup_restoreEnv: "Omgevingsbestand hersteld uit een back-up",
       config_save: "Configuratie opgeslagen",

--- a/client/src/pages/admin/settings.vue
+++ b/client/src/pages/admin/settings.vue
@@ -37,7 +37,7 @@ const envGroupOrder = [
   // they render read-only with their reason - which is the point: an operator needs to
   // see that a seed is in force, and that is exactly why this page cannot be saved.
   { key: 'configuration', label: () => t('settings.settingsPage.tabConfiguration'), icon: 'right-left',
-    exact: ['ENABLE_CONFIG_IN_DATABASE', 'ENABLE_FORMS_YAML_IN_DATABASE', 'CONFIG_SEED_PATH', 'ALLOW_ENV_EDIT'] },
+    exact: ['ENABLE_CONFIG_IN_DATABASE', 'ENABLE_FORMS_YAML_IN_DATABASE', 'CONFIG_SEED_PATH', 'CONFIG_SEED_RELOAD_SECONDS', 'ALLOW_ENV_EDIT'] },
   { key: 'server', label: () => t('settings.settingsPage.envGroupServer'), icon: 'globe',
     // no BASE_URL : it is in OWNED_ELSEWHERE, which is filtered out before the groups are
     // consulted, so listing it here only claimed a variable this page never renders

--- a/docs/_data/help.yaml
+++ b/docs/_data/help.yaml
@@ -219,6 +219,21 @@
       ${ENV_VAR} and resolved from the environment, so the file itself holds none.
       Unrelated to CONFIG_PATH, which holds the forms configuration. An invalid seed makes the
       server refuse to start. See the Config seed page in the documentation.
+  - name: CONFIG_SEED_RELOAD_SECONDS
+    version: 6.3.0
+    type: integer
+    allowed: 0 or a number of seconds
+    short: Config seed reload interval
+    hint: How often the seed file is re-read, so a change in git reaches a running instance
+    default: 60
+    description: |
+      How often the config seed file is checked and re-applied when its content has changed,
+      in seconds. This is what lets a seed edited in git take effect without restarting: on
+      kubernetes a ConfigMap is remounted under the running pod within about a minute and the
+      change is picked up from there. A reload that fails is never fatal, unlike the one at
+      startup: the configuration already in force is kept and the Status page reports it.
+      Set it to 0 to check only at startup, leaving POST /api/v2/config-seed/apply and SIGHUP.
+      Ignored when CONFIG_SEED_PATH is empty.
   - name: ALLOW_ENV_EDIT
     version: 6.3.0
     type: boolean

--- a/docs/seed.md
+++ b/docs/seed.md
@@ -185,10 +185,42 @@ credentials:
 `prune` only ever considers managed records. It cannot delete something somebody made by
 hand.
 
+## Changing the file without restarting
+
+The seed is re-read every `CONFIG_SEED_RELOAD_SECONDS` (60 by default, `0` turns it off)
+and re-applied when its content has changed. A change committed to git therefore reaches a
+running instance on its own: on Kubernetes a `ConfigMap` is remounted under the pod within
+about a minute and the next check picks it up. Nothing is rolled, nothing restarts, and no
+hook has to call anything.
+
+An unchanged file costs one hash and stops there, so the poll never rewrites a row it has
+already applied.
+
+Two ways to ask for it immediately rather than waiting:
+
+```
+POST /api/v2/config-seed/apply     # settings admin ; answers with what it did
+kill -HUP 1                        # inside the container, no credentials needed
+```
+
+Both **force** an apply even when the file has not changed, which is the point of asking:
+it re-asserts a managed record somebody edited straight in the database, and re-clones a
+declared repository whose working tree has gone missing.
+
+{: .note }
+> A reload is **never fatal**, unlike the apply at startup. An instance that is already
+> serving keeps the configuration it has, the reason is logged, and the *Config seed* row on
+> the Status page turns red naming it. A typo pushed to git must not be able to take a
+> running instance down with no operator action at all.
+>
+> The same broken content is not retried on every tick either, or one bad edit would write
+> the same error to the log for ever. Fix the file, or call the endpoint to retry it now.
+
 ## A broken seed refuses to start
 
 An unreadable file, invalid yaml, an unknown field, a duplicate name or an unresolved
-`${VARIABLE}` makes the server **exit** rather than start.
+`${VARIABLE}` makes the server **exit** rather than start. This is the **startup** path
+only: see the note above for what the same file does to an instance that is already up.
 
 That is deliberate. Carrying on with the previous configuration means an instance whose
 behaviour no longer matches the manifest that is supposed to describe it, and nothing
@@ -242,6 +274,10 @@ spec:
           env:
             - name: CONFIG_SEED_PATH
               value: /seed/seed.yaml
+            # a ConfigMap edited in git is remounted here within about a minute and
+            # applied from there, so changing the seed does not roll the pod
+            - name: CONFIG_SEED_RELOAD_SECONDS
+              value: "60"
             # the environment is declared here, so the settings pages must not
             # write persistent/.env behind this manifest's back
             - name: ALLOW_ENV_EDIT
@@ -309,8 +345,14 @@ a durable one drifts away from the manifest that is meant to be authoritative.
 
 Each apply that changes something writes one `seed.apply` entry to the audit log, naming
 the objects created, updated, released and pruned. Values are never recorded, because most
-of them are secrets. A no-op apply writes nothing, so the trail stays meaningful.
+of them are secrets. A no-op apply writes nothing, so the trail stays meaningful, and a
+poll that finds the file unchanged is a no-op - the trail does not gain a row per minute.
 
-The Status page reports the seed twice: a **check** that the file is still readable and
-parseable (a remounted ConfigMap would otherwise only be discovered at the next restart)
-and an **information** row saying how many records it currently owns.
+An apply asked for through the endpoint is recorded twice on purpose, and the two rows say
+different things: `config-seed.apply.create` is **who** asked for it, `seed.apply` is
+**what** it changed.
+
+The Status page reports the seed twice: a **check** that the file is still readable, parses,
+and that the last reload succeeded, and an **information** row saying how many records it
+currently owns. The check is the only place that says the file on disk and the configuration
+in force have parted company, since a failed reload leaves the instance running.

--- a/server/config/app.config.js
+++ b/server/config/app.config.js
@@ -21,6 +21,12 @@ var app_config = {
   // repositories, ldap, mail/url). Empty = feature off. NOT the same thing as configPath,
   // which holds the forms configuration - see docs/seed.md.
   configSeedPath: process.env.CONFIG_SEED_PATH || "",
+  // How often the seed file is re-read and re-applied when its content changed, in
+  // seconds. 0 turns the poll off, leaving the boot apply, POST /api/v2/config-seed/apply
+  // and SIGHUP. A poll rather than a watcher on purpose : a mounted ConfigMap is updated
+  // by swapping the ..data symlink, which fs.watch on the file never sees, and kubelet
+  // takes up to a minute to do it anyway - so a watcher would buy no time it could use.
+  configSeedReloadSeconds: parseInt(process.env.CONFIG_SEED_RELOAD_SECONDS || "60", 10),
   // Whether the settings pages may write persistent/.env. Turn this off where the
   // environment is declared elsewhere (kubernetes ConfigMap, docker-compose, ArgoCD) :
   // there the file is either ephemeral, so a save is silently lost at the next restart,

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ import httpsConfig from './config/https.config.js';
 import { registerHttpsServer } from './src/lib/httpsContext.js';
 import authConfig from './config/auth.config.js';
 import logger from './src/lib/logger.js';
+import { reloadConfigSeed } from './src/lib/seed.js';
 import https from 'https';
 import http from 'http';
 import fs from 'fs';
@@ -97,4 +98,19 @@ async function start(){
   httpServer.listen(appConfig.port,  () => logger.notice(`App running on port ${appConfig.port}!`));
 
 }
+
+// SIGHUP re-applies the config seed : the unix idiom for "re-read your configuration", and
+// the one way in that needs no credentials and no reachable port, which is what makes it
+// worth having from inside a container (`kubectl exec ... -- kill -HUP 1`).
+//
+// Node's default action for SIGHUP is to TERMINATE, so installing this changes what closing
+// the terminal does to a foreground process. That is the trade every daemon makes, and the
+// alternative here is a signal that kills an instance which may be running playbooks.
+process.on('SIGHUP', () => {
+  // never awaited : a signal handler that blocks would hold the event loop while the seed
+  // clones a repository, and reloadConfigSeed reports its own outcome to the log either way
+  reloadConfigSeed({ force: true, trigger: 'SIGHUP' })
+    .catch((err) => logger.error('SIGHUP config seed reload failed : ' + (err.message || err)));
+});
+
 start()

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -74,6 +74,7 @@ import sshRoutesv2 from "./routes/v2/ssh.routes.js";
 import logRoutesv2 from "./routes/v2/log.routes.js";
 import repositoryRoutesv2 from "./routes/v2/repository.routes.js";
 import configRoutesv2 from "./routes/v2/config.routes.js";
+import configSeedRoutesv2 from "./routes/v2/configseed.routes.js";
 import formsReposRoutes from "./routes/v2/forms-repos.routes.js";
 
 // __dirname and __filename setup for ES modules
@@ -253,6 +254,9 @@ const load = async (app) => {
   // forms repositories (issue #414) : designer users can push without settings access
   app.use(`/api/v2/forms-repos`, cors(), authobj, Middleware.checkDesignerMiddleware, formsReposRoutes);
   app.use(`/api/v2/config`, cors(), authobj, configRoutesv2);
+  // separate mount from /config on purpose : the seed is not the forms configuration and
+  // does not share its permissions - this one is settings admin, like the pages it rewrites
+  app.use(`/api/v2/config-seed`, cors(), authobj, Middleware.checkSettingsMiddleware, configSeedRoutesv2);
 }
 
 

--- a/server/src/controllers/v2/configseed.controller.js
+++ b/server/src/controllers/v2/configseed.controller.js
@@ -1,0 +1,45 @@
+'use strict';
+// Re-apply the declarative config seed on demand.
+//
+// The poll in cron.service already picks up a changed file on its own, so this exists for
+// the two cases the poll cannot serve : a deployment hook that wants the seed in force
+// BEFORE it reports success rather than up to a minute later, and an operator who has just
+// fixed a broken file and would rather not wait to find out whether it took.
+//
+// It forces, deliberately. "Nothing changed on disk" is exactly the situation somebody
+// wants to re-assert from here - a managed record edited straight in the database, or a
+// repository whose working tree went missing - and the apply is idempotent, so forcing
+// costs a comparison per declared object and writes nothing when they all match.
+import RestResult from '../../models/restResult.model.v2.js';
+import { reloadConfigSeed } from '../../lib/seed.js';
+import logger from '../../lib/logger.js';
+import i18n from '../../lib/i18n.js';
+
+const configSeedController = {
+  async apply(req, res) {
+    try {
+      const result = await reloadConfigSeed({ force: true, trigger: `api:${req.user?.user?.username || 'unknown'}` });
+
+      if (result.status === 'off') {
+        return res.status(400).json(RestResult.error(i18n.t(req, 'resources.noConfigSeed'), null));
+      }
+      // A failed apply answers 500 with the reason. The instance is fine - it kept the
+      // configuration it already had - but the request did not do what it asked for, and a
+      // CD hook that reads only the status code has to be able to tell.
+      if (result.status === 'failed') {
+        return res.status(500).json(RestResult.error(i18n.t(req, 'resources.failedApplyConfigSeed'), result.error));
+      }
+
+      // Names only, never values : the summary lists what was created, updated, released,
+      // pruned and adopted, and most of what the seed carries is a secret.
+      return res.json(RestResult.single({ status: result.status, summary: result.summary || null }));
+    } catch (err) {
+      // reloadConfigSeed catches everything the apply can throw, so reaching here means a
+      // fault in this handler rather than in the seed. Answer, and say which it was.
+      logger.error('Config seed apply endpoint failed : ' + (err.message || err));
+      return res.status(500).json(RestResult.error(i18n.t(req, 'resources.failedApplyConfigSeed'), err.message || String(err)));
+    }
+  },
+};
+
+export default configSeedController;

--- a/server/src/lib/seed.js
+++ b/server/src/lib/seed.js
@@ -16,10 +16,12 @@
 // the right outcome, but it overwrites what somebody typed, so it is logged as a
 // warning and recorded in the audit entry rather than happening silently.
 //
-// An invalid seed is FATAL on purpose. The alternative - carry on with the previous
-// configuration - means an instance whose behaviour no longer matches the manifest
-// that is supposed to describe it, and nothing says so out loud.
+// An invalid seed is FATAL on purpose AT BOOT. The alternative - come up on the previous
+// configuration - means an instance whose behaviour no longer matches the manifest that is
+// supposed to describe it, and nothing says so out loud. A RELOAD of an already running
+// instance is the opposite : see reloadConfigSeed.
 import fs from "fs";
+import { createHash } from "node:crypto";
 import path from "path";
 import yaml from "yaml";
 import logger from "./logger.js";
@@ -323,7 +325,8 @@ export async function applyConfigSeed({ schemaIsReady = true } = {}) {
   }
 
   logger.notice(`Applying config seed from ${seedPath}`);
-  let doc = yaml.parse(fs.readFileSync(seedPath, "utf8"));
+  const raw = fs.readFileSync(seedPath, "utf8");
+  let doc = yaml.parse(raw);
   // an empty file is a valid seed that declares nothing : it releases everything
   if (doc === null || doc === undefined) doc = {};
   if (typeof doc !== "object" || Array.isArray(doc)) {
@@ -345,8 +348,113 @@ export async function applyConfigSeed({ schemaIsReady = true } = {}) {
     throw e;
   }
 
+  // The hash of what was ACTUALLY applied, taken from the bytes this run read rather than
+  // from whatever the poller looked at a moment earlier. A file rewritten between the two
+  // is then simply applied on this pass instead of being remembered as already applied.
+  lastApplied = { hash: hashOf(raw), at: new Date().toISOString() };
+  lastFailure = { hash: null, error: null, at: null };
+
   await logApply(seedPath, summary, 'success');
   return summary;
+}
+
+// ---------------------------------------------------------------------------------
+// Live reload.
+//
+// The seed used to be the one file read exactly once. Everything else that comes from
+// disk is already refreshed under the running process : repositories have a cron pull,
+// config.yaml has PUT /settings/importConfig, the TLS certificate reloads itself. And
+// health.model's configSeedCheck could already SEE the file change, but the only thing
+// it could say about it was that the NEXT RESTART would refuse to start.
+//
+// Re-applying instead closes that gap. It matters most where the file is not edited by
+// hand at all : on kubernetes a ConfigMap updated from git is remounted under the running
+// pod within about a minute, so a change reaches the instance without rolling it - which
+// is the whole point of declaring the configuration in git in the first place.
+let lastApplied = { hash: null, at: null };
+let lastFailure = { hash: null, error: null, at: null };
+
+function hashOf(raw) {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+/**
+ * What the last apply and the last failed reload did, for the Status page. Deliberately
+ * carries no part of the file itself : almost every value in it is a secret.
+ */
+export function getSeedState() {
+  return {
+    path: appConfig.configSeedPath || null,
+    appliedAt: lastApplied.at,
+    failure: lastFailure.at ? { at: lastFailure.at, error: lastFailure.error } : null,
+  };
+}
+
+// Reset between tests. Not for production use : nothing in the application has any reason
+// to forget what it has applied.
+export function _resetSeedState() {
+  lastApplied = { hash: null, at: null };
+  lastFailure = { hash: null, error: null, at: null };
+}
+
+function recordFailure(hash, err, trigger) {
+  const error = err.message || String(err);
+  lastFailure = { hash, error, at: new Date().toISOString() };
+  logger.error(`Config seed reload (${trigger}) failed, keeping the configuration already in force : ${error}`);
+  return { status: "failed", error };
+}
+
+/**
+ * Re-apply the seed under a running process.
+ *
+ * NEVER fatal, which is the one way this differs from the boot path. Refusing to start is
+ * a safe failure - the old pod keeps serving under a rolling deployment and nothing has
+ * changed anywhere. Exiting an instance that is already up, because a file it watches was
+ * edited badly, would take the application down with no operator action at all - a typo in
+ * git would be enough. So a failed reload keeps the configuration already in force, says so
+ * in the log, and turns the Status page's seed row red.
+ *
+ * @param {object}  [opts]
+ * @param {boolean} [opts.force]   Apply even if the file is unchanged (the API and SIGHUP).
+ * @param {string}  [opts.trigger] Where the call came from, for the log line.
+ * @returns {Promise<object>} `{status}`, one of :
+ *   off       - CONFIG_SEED_PATH is not set, nothing to do
+ *   unchanged - byte for byte what was applied last
+ *   skipped   - broken, and unchanged since it last failed
+ *   applied   - re-applied, with the summary
+ *   failed    - threw ; the previous configuration is kept
+ */
+export async function reloadConfigSeed({ force = false, trigger = "poll" } = {}) {
+  const seedPath = appConfig.configSeedPath;
+  if (!seedPath) return { status: "off" };
+
+  let raw;
+  try {
+    raw = fs.readFileSync(seedPath, "utf8");
+  } catch (e) {
+    // A file that has gone missing is a failed reload like any other. The instance keeps
+    // running on what it already applied, which is exactly what the operator would want
+    // while a ConfigMap is being remounted underneath it.
+    return recordFailure(null, e, trigger);
+  }
+
+  const hash = hashOf(raw);
+  if (!force) {
+    if (hash === lastApplied.hash) return { status: "unchanged" };
+    // The same broken content as last time. Re-reading it every tick would write an
+    // identical error to the log for ever and could not end differently : the file has to
+    // change, or somebody has to ask for it explicitly, before another attempt is worth
+    // anything. The Status page keeps reporting it in the meantime, so it is not lost.
+    if (hash === lastFailure.hash) return { status: "skipped", error: lastFailure.error };
+  }
+
+  logger.notice(`Config seed re-apply triggered (${trigger})`);
+  try {
+    const summary = await applyConfigSeed();
+    return { status: "applied", summary };
+  } catch (e) {
+    return recordFailure(hash, e, trigger);
+  }
 }
 
 async function applySections(doc, summary) {
@@ -415,4 +523,4 @@ async function logApply(seedPath, summary, outcome) {
 }
 
 export { listSections };
-export default { applyConfigSeed };
+export default { applyConfigSeed, reloadConfigSeed, getSeedState };

--- a/server/src/locales/de.js
+++ b/server/src/locales/de.js
@@ -94,6 +94,8 @@ export default {
     failedPullRepository: "Repository konnte nicht gepullt werden",
     failedSyncRepository: "Repository konnte nicht synchronisiert werden",
     noFormsRepositories: "Keine Forms-Repositories konfiguriert",
+    failedApplyConfigSeed: "Konfigurations-Seed konnte nicht angewendet werden",
+    noConfigSeed: "Es ist kein Konfigurations-Seed konfiguriert (CONFIG_SEED_PATH ist leer)",
     failedFindSsh: "SSH-Schluessel konnte nicht gefunden werden",
     failedUpdateSsh: "SSH-Schluessel konnte nicht aktualisiert werden",
     failedFindLdap: "LDAP konnte nicht gefunden werden",

--- a/server/src/locales/en.js
+++ b/server/src/locales/en.js
@@ -94,6 +94,8 @@ export default {
     failedPullRepository: "Failed to pull repository",
     failedSyncRepository: "Failed to sync repository",
     noFormsRepositories: "No forms repositories configured",
+    failedApplyConfigSeed: "Failed to apply the config seed",
+    noConfigSeed: "No config seed is configured (CONFIG_SEED_PATH is empty)",
     failedFindSsh: "Failed to find SSH key",
     failedUpdateSsh: "Failed to update SSH key",
     failedFindLdap: "Failed to find LDAP",

--- a/server/src/locales/es.js
+++ b/server/src/locales/es.js
@@ -94,6 +94,8 @@ export default {
     failedPullRepository: "Error al actualizar el repositorio",
     failedSyncRepository: "Error al sincronizar el repositorio",
     noFormsRepositories: "No hay repositorios de formularios configurados",
+    failedApplyConfigSeed: "Error al aplicar el seed de configuracion",
+    noConfigSeed: "No hay ningun seed de configuracion configurado (CONFIG_SEED_PATH esta vacio)",
     failedFindSsh: "Error al buscar la clave SSH",
     failedUpdateSsh: "Error al actualizar la clave SSH",
     failedFindLdap: "Error al buscar LDAP",

--- a/server/src/locales/fr.js
+++ b/server/src/locales/fr.js
@@ -94,6 +94,8 @@ export default {
     failedPullRepository: "Echec du pull du depot",
     failedSyncRepository: "Échec de la synchronisation du dépôt",
     noFormsRepositories: "Aucun dépôt de formulaires configuré",
+    failedApplyConfigSeed: "Echec de l'application du seed de configuration",
+    noConfigSeed: "Aucun seed de configuration n'est configure (CONFIG_SEED_PATH est vide)",
     failedFindSsh: "Echec de la recherche de la cle SSH",
     failedUpdateSsh: "Echec de la mise a jour de la cle SSH",
     failedFindLdap: "Echec de la recherche LDAP",

--- a/server/src/locales/it.js
+++ b/server/src/locales/it.js
@@ -94,6 +94,8 @@ export default {
     failedPullRepository: "Impossibile fare pull del repository",
     failedSyncRepository: "Impossibile sincronizzare il repository",
     noFormsRepositories: "Nessun repository di moduli configurato",
+    failedApplyConfigSeed: "Impossibile applicare il seed di configurazione",
+    noConfigSeed: "Nessun seed di configurazione e configurato (CONFIG_SEED_PATH e vuoto)",
     failedFindSsh: "Impossibile trovare la chiave SSH",
     failedUpdateSsh: "Impossibile aggiornare la chiave SSH",
     failedFindLdap: "Impossibile trovare LDAP",

--- a/server/src/locales/nl.js
+++ b/server/src/locales/nl.js
@@ -94,6 +94,8 @@ export default {
     failedPullRepository: "Kan repository niet pullen",
     failedSyncRepository: "Repository synchroniseren mislukt",
     noFormsRepositories: "Geen forms repositories geconfigureerd",
+    failedApplyConfigSeed: "Kan de configuratie-seed niet toepassen",
+    noConfigSeed: "Er is geen configuratie-seed geconfigureerd (CONFIG_SEED_PATH is leeg)",
     failedFindSsh: "Kan SSH sleutel niet vinden",
     failedUpdateSsh: "Kan SSH sleutel niet bijwerken",
     failedFindLdap: "Kan LDAP niet vinden",

--- a/server/src/models/health.model.js
+++ b/server/src/models/health.model.js
@@ -7,6 +7,7 @@ import cronService from '../services/cron.service.js';
 import appConfig from '../../config/app.config.js';
 import logConfig from '../../config/log.config.js';
 import Vault from '../lib/vault.js';
+import { getSeedState } from '../lib/seed.js';
 import net from 'net';
 import tls from 'tls';
 import logger from '../lib/logger.js';
@@ -650,11 +651,14 @@ async function writableCheck() {
 }
 
 /**
- * The declarative config seed. A bad seed refuses to start, so this can never report
- * a seed that failed to apply - the process would not be here to answer. What it does
- * catch is the file going away or becoming unreadable AFTER boot, which is a live risk
- * on kubernetes : a remounted or renamed ConfigMap means the next restart fails, and
- * this is the only place that says so while the instance is still up.
+ * The declarative config seed. A bad seed refuses to START, so a file that never applied
+ * cannot be reported from here - the process would not be up to answer. A bad RELOAD is
+ * the opposite : it is survivable on purpose, the instance keeps the configuration it
+ * already had, and then this row is the only thing that says the file on disk and the
+ * configuration in force have parted company.
+ *
+ * It also still catches the file going away or becoming unreadable, which is a live risk
+ * on kubernetes where a ConfigMap can be remounted or renamed underneath a running pod.
  *
  * Side-effect free, like every row on this page : the file is read, never applied.
  */
@@ -663,6 +667,19 @@ async function configSeedCheck() {
   if (!seedPath) {
     return check('configSeed', OK, 'not configured',
       { note: 'Set CONFIG_SEED_PATH to declare the admin objects in a file - see docs/seed.md' });
+  }
+  // Before anything read from disk : a failed reload means what is on disk is NOT what is
+  // running, so reporting the file as healthy would describe configuration nobody applied.
+  const state = getSeedState();
+  if (state.failure) {
+    return check('configSeed', ERROR, 'last reload failed',
+      {
+        path: seedPath,
+        reason: state.failure.error,
+        failedAt: state.failure.at,
+        appliedAt: state.appliedAt,
+        note: 'The configuration in force is the one applied before the failed reload. Fix the file, or POST /api/v2/config-seed/apply to retry it now',
+      });
   }
   try {
     await fs.access(seedPath, fsConstants.R_OK);

--- a/server/src/routes/v2/configseed.routes.js
+++ b/server/src/routes/v2/configseed.routes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+const router = express.Router();
+import configSeedController from '../../controllers/v2/configseed.controller.js';
+
+// Settings admin only, mounted with checkSettingsMiddleware in app.js : applying the seed
+// rewrites awx connections, credentials, oauth2 providers, repositories, ldap and the mail
+// settings, which is the same reach as the pages that own them.
+router.post('/apply', configSeedController.apply);
+
+export default router;

--- a/server/src/services/cron.service.js
+++ b/server/src/services/cron.service.js
@@ -10,6 +10,9 @@ import Schedule from '../models/schedule.model.js';
 // imported rather than injected like Job/Token/BackupModel : audit.model only pulls
 // in the db pool and the logger, so there is no cycle to avoid here
 import Audit from '../models/audit.model.js';
+// same reasoning as Audit : lib/seed pulls in the models and the logger, and nothing it
+// touches imports this service back, so there is no cycle to avoid by injecting it
+import { reloadConfigSeed } from '../lib/seed.js';
 import logConfig from '../../config/log.config.js';
 import dayjs from 'dayjs';
 
@@ -534,6 +537,34 @@ class CronService {
     });
     this.jobs.system.set('storedJobsCleanup', storedJobsCleanupTask);
     logger.info('Initialized stored jobs cleanup (daily at 4:00 AM)');
+
+    // 5. Config seed reload - re-applies CONFIG_SEED_PATH when its content changes
+    //
+    // Registered here rather than as a watcher of its own so it stops with everything
+    // else, and so the seed is refreshed by the same machinery that already refreshes
+    // the repositories. `interval` is croner's own throttle : the pattern fires every
+    // second and the option holds each run back until the interval has passed, which is
+    // how an arbitrary number of seconds is expressed - a `*/n` pattern silently breaks
+    // for anything above 59.
+    const seedReloadSeconds = appConfig.configSeedReloadSeconds;
+    if (appConfig.configSeedPath && seedReloadSeconds > 0) {
+      const configSeedTask = new Cron('* * * * * *', {
+        timezone: this.timezone,
+        interval: seedReloadSeconds,
+        // an apply that runs long (a seeded repository being cloned) must not have a
+        // second one started on top of it
+        protect: true
+      }, async () => {
+        // reloadConfigSeed handles its own failures - it must never throw into the
+        // scheduler, because a rejection here would leave the tick counted and the
+        // reason logged by croner rather than by the seed
+        await reloadConfigSeed({ trigger: 'poll' });
+      });
+      this.jobs.system.set('configSeedReload', configSeedTask);
+      logger.info(`Initialized config seed reload (every ${seedReloadSeconds}s)`);
+    } else if (appConfig.configSeedPath) {
+      logger.info('Config seed reload is off (CONFIG_SEED_RELOAD_SECONDS=0), the seed applies at startup only');
+    }
 
     logger.info('System maintenance tasks initialization complete');
   }

--- a/server/tests/config-seed-reload.test.mjs
+++ b/server/tests/config-seed-reload.test.mjs
@@ -1,0 +1,177 @@
+// Re-applying the config seed under a RUNNING process (CONFIG_SEED_RELOAD_SECONDS,
+// POST /api/v2/config-seed/apply, SIGHUP).
+//
+// Four properties carry this feature, and every one of them fails silently :
+//
+//  1. An unchanged file must not be re-applied. The poll runs every minute for the life of
+//     the instance, so an apply per tick would rewrite every managed row for ever - and
+//     each rewrite of a credential is a fresh encryption, which the audit trail would
+//     record as a change that nobody made.
+//  2. A changed file MUST be applied, or the whole feature is decoration and the operator
+//     believes a change reached the instance when it did not.
+//  3. A bad reload must NOT be fatal. At boot it is - refusing to start is safe, the old
+//     pod keeps serving. Exiting an instance that is already up because a file it watches
+//     was edited badly would take the application down with no operator action at all.
+//  4. The same broken content must not be retried every tick, or one typo writes an
+//     identical error to the log for ever while nothing about the outcome can differ.
+import { test, describe, beforeEach, afterEach, vi } from "vitest";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+process.env.DB_HOST ||= "127.0.0.1";
+process.env.DB_PORT ||= "3306";
+process.env.DB_USER ||= "test";
+process.env.DB_PASSWORD ||= "test";
+
+// Nothing here touches mysql : every query answers with an empty result, which for the
+// sections an empty seed declares is exactly what a converged database returns.
+const queries = [];
+let dbHandler = async () => [];
+vi.mock("../src/models/db.model.js", () => ({
+  default: {
+    do: async (sql, vars) => {
+      queries.push({ sql, vars });
+      return dbHandler(sql, vars);
+    },
+  },
+}));
+
+// the same object lib/seed.js sees : vitest.config aliases '../../config/app.config.js'
+// to this mock, so importing the real file here would set the path on a different object
+const appConfig = (await import("./__mocks__/app.config.js")).default;
+const { applyConfigSeed, reloadConfigSeed, getSeedState, _resetSeedState } =
+  await import("../src/lib/seed.js");
+
+let dir;
+let seedPath;
+
+// An empty-but-valid seed. It declares nothing, so applying it is a complete run of the
+// real code path - every section, the release sweep, the audit decision - that touches no
+// row, which is what makes it usable without a database.
+const EMPTY_SEED = "version: 1\n";
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "af-seed-reload-"));
+  seedPath = path.join(dir, "seed.yaml");
+  fs.writeFileSync(seedPath, EMPTY_SEED);
+  appConfig.configSeedPath = seedPath;
+  _resetSeedState();
+  queries.length = 0;
+  dbHandler = async () => [];
+});
+
+afterEach(() => {
+  appConfig.configSeedPath = "";
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("reloading the config seed", () => {
+  test("does nothing at all when no seed is configured", async () => {
+    appConfig.configSeedPath = "";
+    assert.deepEqual(await reloadConfigSeed(), { status: "off" });
+  });
+
+  test("applies a file it has not seen", async () => {
+    const result = await reloadConfigSeed();
+    assert.equal(result.status, "applied");
+    assert.ok(result.summary, "an applied reload reports what it did");
+  });
+
+  // The property that keeps the poll from rewriting the database every minute.
+  test("leaves an unchanged file alone on the next tick", async () => {
+    assert.equal((await reloadConfigSeed()).status, "applied");
+    assert.equal((await reloadConfigSeed()).status, "unchanged");
+    assert.equal((await reloadConfigSeed()).status, "unchanged");
+  });
+
+  // The boot apply has to seed the same state, or the FIRST poll of every instance would
+  // re-apply a file that had just been applied seconds earlier.
+  test("the apply at startup counts, so the first poll is already a no-op", async () => {
+    await applyConfigSeed();
+    assert.equal((await reloadConfigSeed()).status, "unchanged");
+  });
+
+  test("applies again once the content changes", async () => {
+    await reloadConfigSeed();
+    fs.writeFileSync(seedPath, "version: 1\nawx:\n  items: []\n");
+    assert.equal((await reloadConfigSeed()).status, "applied");
+  });
+
+  test("force applies even when nothing changed, which is what the endpoint asks for", async () => {
+    await reloadConfigSeed();
+    assert.equal((await reloadConfigSeed()).status, "unchanged");
+    assert.equal((await reloadConfigSeed({ force: true })).status, "applied");
+  });
+});
+
+describe("a reload that fails keeps the instance running", () => {
+  test("a schema violation is reported, not thrown", async () => {
+    await reloadConfigSeed();
+    fs.writeFileSync(seedPath, "version: 1\nawx:\n  items:\n    - name: t\n      uri: u\n      tokenn: x\n");
+
+    const result = await reloadConfigSeed();
+    assert.equal(result.status, "failed");
+    assert.match(result.error, /validation failed/);
+  });
+
+  test("the failure is visible to the Status page instead of only the log", async () => {
+    await reloadConfigSeed();
+    fs.writeFileSync(seedPath, "this: is: not: valid: yaml:\n");
+    await reloadConfigSeed();
+
+    const state = getSeedState();
+    assert.ok(state.failure, "getSeedState reports the failed reload");
+    assert.ok(state.failure.at, "with when it happened");
+    assert.ok(state.appliedAt, "and still remembers the apply that IS in force");
+  });
+
+  test("the same broken content is not retried on every tick", async () => {
+    await reloadConfigSeed();
+    fs.writeFileSync(seedPath, "version: 1\nnope: {}\n");
+
+    assert.equal((await reloadConfigSeed()).status, "failed");
+    assert.equal((await reloadConfigSeed()).status, "skipped");
+    assert.equal((await reloadConfigSeed()).status, "skipped");
+  });
+
+  test("but asking explicitly retries it, because that is why somebody asked", async () => {
+    await reloadConfigSeed();
+    fs.writeFileSync(seedPath, "version: 1\nnope: {}\n");
+    await reloadConfigSeed();
+    assert.equal((await reloadConfigSeed()).status, "skipped");
+    assert.equal((await reloadConfigSeed({ force: true })).status, "failed");
+  });
+
+  test("fixing the file clears the failure and applies it", async () => {
+    await reloadConfigSeed();
+    fs.writeFileSync(seedPath, "version: 1\nnope: {}\n");
+    await reloadConfigSeed();
+    assert.ok(getSeedState().failure);
+
+    fs.writeFileSync(seedPath, "version: 1\nawx:\n  items: []\n");
+    assert.equal((await reloadConfigSeed()).status, "applied");
+    assert.equal(getSeedState().failure, null, "a good apply clears the reported failure");
+  });
+
+  // A ConfigMap being remounted can leave the path missing for a moment. That must read as
+  // a failed reload on a running instance, never as a crash.
+  test("a file that has gone away is a failed reload, not an exception", async () => {
+    await reloadConfigSeed();
+    fs.rmSync(seedPath);
+
+    const result = await reloadConfigSeed();
+    assert.equal(result.status, "failed");
+    assert.ok(getSeedState().failure);
+  });
+
+  test("and a file that comes back is applied again", async () => {
+    await reloadConfigSeed();
+    fs.rmSync(seedPath);
+    await reloadConfigSeed();
+
+    fs.writeFileSync(seedPath, "version: 1\nawx:\n  items: []\n");
+    assert.equal((await reloadConfigSeed()).status, "applied");
+  });
+});


### PR DESCRIPTION
## What

The seed is re-read every `CONFIG_SEED_RELOAD_SECONDS` (60 by default, `0` turns it off) and re-applied when its content has changed, so a seed edited in git reaches a running instance without restarting it. `POST /api/v2/config-seed/apply` and `SIGHUP` force an apply immediately.

## Why

The seed is the only configuration file this application reads exactly once. Everything else that comes from disk is already refreshed under the running process: repositories have a cron pull, `config.yaml` has `PUT /settings/importConfig`, the TLS certificate reloads itself in `httpsContext`. And `configSeedCheck` in health.model could already *see* the file change, but the only thing it could say about it was that the next restart would refuse to start. It could report the drift and do nothing about it.

That gap costs the most exactly where the seed is meant to shine. On Kubernetes a ConfigMap edited in git is remounted under the running pod within about a minute, and nothing happened with it: the change only took effect if somebody rolled the deployment, which for a single-instance application means an interruption to pick up a one line edit. Declaring the configuration in git and then needing a restart to apply it is half a feature.

## How it behaves

* An unchanged file costs one sha256 and stops there, so the poll never rewrites a row it has already applied. That matters more than it looks: every rewrite of a credential is a fresh encryption, and the audit trail would otherwise record a change nobody made, once a minute, for ever.
* The apply at startup records the same state, so the first poll of every instance is already a no-op.
* `POST /api/v2/config-seed/apply` (settings admin) and `SIGHUP` both **force**, which is the point of asking: forcing re-asserts a managed record somebody edited straight in the database, and re-clones a declared repository whose working tree has gone missing. The apply is idempotent, so forcing costs a comparison per declared object and writes nothing when they all match.
* The endpoint answers 500 with the reason when the apply fails, so a CD hook that reads only the status code can tell.

## A reload is never fatal

This is the one way it differs from the apply at startup, and it is deliberate. Refusing to start is a *safe* failure: under a rolling deployment the old pod keeps serving and nothing changed anywhere. Exiting an instance that is already up, because a file it watches was edited badly, would take the application down with no operator action at all. A typo pushed to git would be enough.

So a failed reload keeps the configuration already in force, logs the reason, and turns the Status page's `configSeed` row red naming it. The same broken content is not retried on every tick either, or one bad edit writes an identical error to the log for ever while nothing about the outcome can differ. Fixing the file, or calling the endpoint, picks it up again.

The Status check had to move first, before anything it reads from disk: a failed reload means what is on disk is *not* what is running, so reporting the file as healthy would describe configuration nobody applied.

## Implementation notes

* The poll is registered as a system task in `cron.service` beside the repository pulls, rather than as a watcher of its own. A mounted ConfigMap is updated by swapping the `..data` symlink, which `fs.watch` on the file never sees, and kubelet takes up to a minute to do it anyway, so a watcher would buy no time it could use. `protect: true` keeps a long apply from having a second one started on top of it.
* The hash stored is of the bytes the apply actually read, not of what the poller looked at a moment earlier, so a file rewritten between the two is applied on that pass instead of being remembered as already applied.
* `SIGHUP` changes what closing a terminal does to a foreground process, since Node's default action for it is to terminate. That is the trade every daemon makes, and the alternative here is a signal that kills an instance which may be running playbooks.
* The endpoint is mounted separately from `/api/v2/config`: the seed is not the forms configuration and does not share its permissions.
* An apply asked for through the endpoint is recorded twice on purpose and the rows say different things: `config-seed.apply.create` is who asked, `seed.apply` is what changed.

## Testing

* `server/tests/config-seed-reload.test.mjs`, 13 tests over the four properties that fail silently: an unchanged file is not re-applied, a changed one is, a bad reload is reported rather than thrown, and the same broken content is not retried every tick. Also the ConfigMap case where the file disappears for a moment and comes back.
* Whole suite green, 865 server tests and 249 client tests, both lints clean. The client's env tab coverage test caught the new variable missing from the settings page, which is now on the Configuration tab beside `CONFIG_SEED_PATH`.
* `docs/seed.md` gains a *Changing the file without restarting* section, and the Kubernetes manifest shows the variable.

A follow up that would pair well with this: the server has no `SIGTERM` handler at all, so `terminationGracePeriodSeconds: 120` in the manifest in `docs/seed.md` does not do what the comment next to it says. The process exits at once and `Job.abandon(true)` marks those playbooks abandoned on the next boot. Happy to send that separately.
