### PR TITLE
fix: expression placeholders inside a string are no longer quoted

### DIFF
--- a/client/src/components/AppForm.vue
+++ b/client/src/components/AppForm.vue
@@ -1417,21 +1417,17 @@ function replacePlaceholderInString(value, ignoreIncomplete = false, mode = 'raw
                 fieldvalue = "__null__"   // catch null values
             }
             if (mode === 'expression' && fieldvalue !== "__undefined__" && fieldvalue !== "__null__") {
-                // A JS literal, replacing any quotes that wrapped the placeholder. JSON
-                // keeps a real number a number, so `$(count) + 1` still adds. The
-                // __undefined__/__null__ sentinels stay on the raw path because the
+                // An expression is JS source, so the substitution depends on where the
+                // placeholder sits : quotes that wrap it are replaced along with it by a JS
+                // literal (an apostrophe in the value cannot break out), a placeholder inside
+                // a longer string is escaped and spliced in as text (a JS literal there
+                // injected its own quotes into the middle of the string), and outside a
+                // string a literal keeps a number a number so `$(count) + 1` still adds.
+                // The __undefined__/__null__ sentinels stay on the raw path because the
                 // post-processing below strips their quotes by string match.
                 // isObjectLiteral : fieldvalue is already valid JS/JSON source (array/object) -
                 // stringifying it again would wrap it as a quoted string instead of splicing it in
-                const literal = isObjectLiteral ? fieldvalue : JSON.stringify(fieldvalue)
-                const escaped = foundmatch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-                // a FUNCTION replacement, so the value is inserted verbatim. As a string it
-                // goes through the special replacement patterns : a field containing $& was
-                // replaced by the placeholder text itself, $` and $' by the surrounding
-                // text, and $1 by a capture group - silently corrupting the expression.
-                // (the \\$& two lines up is the opposite case and is deliberate : that one
-                // IS a replacement pattern, escaping the regex metacharacter it matched.)
-                value = value?.replace(new RegExp(`'${escaped}'|"${escaped}"|${escaped}`), () => literal)
+                value = Helpers.substituteExpressionPlaceholder(value, foundmatch, fieldvalue, isObjectLiteral)
             } else {
                 fieldvalue = stringifyValue(fieldvalue)
                 // exactly what was substituted here, so the server substituting the same

--- a/client/src/lib/Helpers.js
+++ b/client/src/lib/Helpers.js
@@ -584,6 +584,81 @@ const Helpers = {
       return `$(${match})` // return original
     }
   },  
+  /**
+   * Splice a resolved value into an expression, at the FIRST occurrence of its placeholder.
+   *
+   * An expression is JS source, so where the placeholder sits decides how the value has to
+   * be written - and getting that wrong is silent, because the result is still valid JS:
+   *
+   *   fn.fnLs('$(dir)')            the quotes wrap the placeholder -> they are replaced
+   *                                together with it by a JS literal, so a value carrying an
+   *                                apostrophe ("O'Brien") cannot break out of the string
+   *   fn.fnLs('$(dir)/vars')       the placeholder is INSIDE a longer string -> the value is
+   *                                escaped for that quote character and spliced in as text.
+   *                                A JS literal here injected its own quotes into the middle
+   *                                of the string : '$(dir)/vars' with /app/persistent became
+   *                                '"/app/persistent"/vars', which is what ENOENT'd on every
+   *                                path and url built this way (the documented AWX examples
+   *                                in docs/faq.md are all of this shape).
+   *   $(count) + 1                 no string at all -> a JS literal, so a number stays a
+   *                                number and still adds instead of concatenating.
+   *
+   * @param {string} expression   the expression still holding the placeholder
+   * @param {string} placeholder  the literal placeholder text, e.g. "$(dir)"
+   * @param {*} value             the resolved value, or its JS source when isSource is set
+   * @param {boolean} isSource    value is already JS/JSON source (an array/object literal)
+   *                              and must be spliced in as-is rather than stringified
+   * @returns {string} the expression with that one occurrence substituted
+   */
+  substituteExpressionPlaceholder(expression, placeholder, value, isSource = false) {
+    const at = expression.indexOf(placeholder);
+    if (at < 0) return expression;
+    const end = at + placeholder.length;
+    const quote = this.quoteContextAt(expression, at);
+    // Everything below concatenates slices : a value containing $& or $1 must never be read
+    // as a replacement pattern, which is what String.replace with a string replacement does.
+    if (!quote) {
+      const literal = isSource ? value : JSON.stringify(value);
+      return expression.slice(0, at) + literal + expression.slice(end);
+    }
+    if (expression[at - 1] === quote && expression[end] === quote) {
+      const literal = isSource ? value : JSON.stringify(value);
+      return expression.slice(0, at - 1) + literal + expression.slice(end + 1);
+    }
+    // JSON escapes \ , " and the control characters ; the enclosing quote is added on top,
+    // and a real newline becoming \n also keeps the expression on one line, which the
+    // server refuses outright.
+    // isSource : the JSON text of an array/object is spliced in as text too, so its own
+    // quotes get escaped for the string it lands in and it reads back identically.
+    const body = JSON.stringify(String(value)).slice(1, -1);
+    const text = quote === "'" ? body.replace(/'/g, "\\'") : body;
+    return expression.slice(0, at) + text + expression.slice(end);
+  },
+
+  /**
+   * Which quote character, if any, encloses position `index` of a JS expression.
+   *
+   * Only ' and " are string delimiters here : a backtick is refused outright by the server
+   * expression sanitizer, so a template literal never reaches evaluation anyway.
+   *
+   * @param {string} expression
+   * @param {number} index
+   * @returns {string|null} the enclosing quote character, or null outside any string
+   */
+  quoteContextAt(expression, index) {
+    let quote = null;
+    for (let i = 0; i < index; i++) {
+      const c = expression[i];
+      if (quote) {
+        if (c === '\\') { i++; continue; }   // an escaped character, quote included
+        if (c === quote) quote = null;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+      }
+    }
+    return quote;
+  },
+
   forceFileDownload(response) {
     const url = window.URL.createObjectURL(new Blob([response.data]))
     const link = document.createElement('a')

--- a/client/tests/expression-placeholders.test.js
+++ b/client/tests/expression-placeholders.test.js
@@ -1,0 +1,175 @@
+// Placeholder substitution into an EXPRESSION (Helpers.substituteExpressionPlaceholder,
+// used by AppForm's replacePlaceholderInString in 'expression' mode).
+//
+// An expression is JS source, so a value cannot simply be pasted in: it has to be written
+// the way the position it lands in requires. Every failure here is silent - the result is
+// still syntactically valid JS, it just means something else - so each case below is one
+// that has been, or would be, wrong in a way nothing else catches:
+//
+//   - a placeholder inside a longer string got a JS literal, so its quotes ended up in the
+//     middle of the string : fn.fnReadYamlFile('$(BASEDIR)/playbooks/vars/clusters.yml')
+//     resolved to '"/app/dist/persistent"/playbooks/...' and ENOENT'd on every path and
+//     url built that way (the documented AWX examples in docs/faq.md are all this shape)
+//   - a quoted placeholder must take the quotes WITH it, or a value carrying an apostrophe
+//     closes the string early and the rest of it is read as code
+//   - a bare placeholder must stay a JS literal, or `$(count) + 1` concatenates
+//   - the value is never a replacement pattern : $& , $1 and friends must be inserted
+//     verbatim, not re-interpreted against the match
+import { describe, it, expect } from 'vitest';
+import Helpers from '@/lib/Helpers';
+
+const sub = (expression, placeholder, value, isSource = false) =>
+  Helpers.substituteExpressionPlaceholder(expression, placeholder, value, isSource);
+
+// What the expression evaluates to once substituted. eval is what the real thing does with
+// it (server side, or in the sandbox for runLocal), so the assertions are about the VALUE
+// the form ends up with, not about the text. `fn` stands in for the function library and is
+// reached by name from inside eval, exactly as expression.model.js resolves it.
+const evaluate = (expression) => {
+  // eslint-disable-next-line no-unused-vars -- referenced by name from the eval'd expression
+  const fn = {
+    echo: (v) => v,
+    upper: (v) => String(v).toUpperCase(),
+    fnLs: (p) => p,
+    fnReadYamlFile: (p) => p,
+    fnRestBasic: (url, method) => `${method}:${url}`,
+    fnJq: (o) => o,
+  };
+  return eval(expression);
+};
+
+describe('a placeholder inside a longer string', () => {
+  it('does not inject quotes into the string', () => {
+    const out = sub("fn.fnReadYamlFile('$(BASEDIR)/playbooks/vars/clusters.yml')",
+      '$(BASEDIR)', '/app/dist/persistent');
+    expect(out).toBe("fn.fnReadYamlFile('/app/dist/persistent/playbooks/vars/clusters.yml')");
+    expect(evaluate(out)).toBe('/app/dist/persistent/playbooks/vars/clusters.yml');
+  });
+
+  it('works the same in a double quoted string', () => {
+    const out = sub('fn.fnLs("$(dir)/sub")', '$(dir)', '/data');
+    expect(out).toBe('fn.fnLs("/data/sub")');
+  });
+
+  it('keeps a url query intact', () => {
+    // docs/faq.md : fn.fnRestJwtSecure('get','https://.../job_templates?organization=$(organization)',...)
+    const out = sub("'https://awx/api/v2/job_templates?organization=$(organization)'",
+      '$(organization)', 'my org');
+    expect(evaluate(out)).toBe('https://awx/api/v2/job_templates?organization=my org');
+  });
+
+  it('escapes the enclosing quote so the value cannot end the string', () => {
+    const out = sub("fn.upper('hello $(name)')", '$(name)', "O'Brien");
+    expect(evaluate(out)).toBe("HELLO O'BRIEN");
+  });
+
+  it('escapes a backslash rather than starting an escape sequence', () => {
+    const out = sub("fn.echo('$(path)\\\\file.txt')", '$(path)', 'C:\\temp');
+    expect(evaluate(out)).toBe('C:\\temp\\file.txt');
+  });
+
+  it('escapes a real newline, keeping the expression on one line', () => {
+    const out = sub("fn.echo('x $(text)')", '$(text)', 'a\nb');
+    expect(out).not.toMatch(/\n/);
+    expect(evaluate(out)).toBe('x a\nb');
+  });
+});
+
+describe('a placeholder wrapped in quotes', () => {
+  it('replaces the quotes together with the placeholder', () => {
+    const out = sub("fn.fnReadYamlFile('$(file)')", '$(file)', '/app/persistent/x.yml');
+    expect(evaluate(out)).toBe('/app/persistent/x.yml');
+  });
+
+  it('cannot be broken out of by a value carrying the same quote', () => {
+    const out = sub("fn.echo('$(name)')", '$(name)', "O'Brien");
+    expect(evaluate(out)).toBe("O'Brien");
+  });
+
+  it('splices an array in as source, not as a quoted string', () => {
+    const out = sub("fn.fnJq('$(rows)')", '$(rows)', '[{"id":7}]', true);
+    expect(out).toBe('fn.fnJq([{"id":7}])');
+    expect(evaluate(out)).toEqual([{ id: 7 }]);
+  });
+
+  it('leaves the other arguments alone', () => {
+    const out = sub("fn.fnRestBasic('$(url)','get')", '$(url)', 'https://host/api');
+    expect(out).toBe('fn.fnRestBasic("https://host/api",\'get\')');
+    expect(evaluate(out)).toBe('get:https://host/api');
+  });
+});
+
+describe('a placeholder outside any string', () => {
+  it('keeps a number a number, so arithmetic still adds', () => {
+    expect(evaluate(sub('$(count) + 1', '$(count)', 5))).toBe(6);
+  });
+
+  it('writes a string as a literal', () => {
+    expect(evaluate(sub("$(name) + 'x'", '$(name)', 'srv1'))).toBe('srv1x');
+  });
+
+  it('keeps a boolean a boolean', () => {
+    expect(evaluate(sub('$(flag) ? 1 : 2', '$(flag)', false))).toBe(2);
+  });
+
+  it('splices an array in as source', () => {
+    expect(evaluate(sub('$(rows).length', '$(rows)', '[1,2,3]', true))).toBe(3);
+  });
+});
+
+describe('the value is never read as a replacement pattern', () => {
+  // String.replace with a STRING replacement re-interprets $& , $` , $' and $1 against the
+  // match - a value containing any of them silently became the placeholder text, the
+  // surrounding text, or a capture group.
+  for (const evil of ['$&', "$'", '$`', '$1', '$$']) {
+    it(`inserts ${evil} verbatim inside a string`, () => {
+      expect(evaluate(sub("fn.echo('x $(v) y')", '$(v)', evil))).toBe(`x ${evil} y`);
+    });
+    it(`inserts ${evil} verbatim as a literal`, () => {
+      expect(evaluate(sub("fn.echo('$(v)')", '$(v)', evil))).toBe(evil);
+    });
+  }
+});
+
+describe('several placeholders in one expression', () => {
+  it('substitutes one occurrence at a time, left to right', () => {
+    let out = sub("fn.echo('$(a)/$(b)')", '$(a)', 'first');
+    out = sub(out, '$(b)', 'second');
+    expect(evaluate(out)).toBe('first/second');
+  });
+
+  it('handles the same placeholder twice', () => {
+    let out = sub("fn.echo('$(a)-$(a)')", '$(a)', 'x');
+    out = sub(out, '$(a)', 'y');
+    expect(evaluate(out)).toBe('x-y');
+  });
+
+  it('mixes a quoted and an embedded one', () => {
+    let out = sub("fn.fnRestBasic('$(url)/items?q=$(q)','get')", '$(url)', 'https://host');
+    out = sub(out, '$(q)', 'a b');
+    expect(out).toBe("fn.fnRestBasic('https://host/items?q=a b','get')");
+  });
+
+  it('returns the expression unchanged when the placeholder is absent', () => {
+    expect(sub("fn.echo('x')", '$(missing)', 'v')).toBe("fn.echo('x')");
+  });
+});
+
+describe('the quote context scanner', () => {
+  it('reports no quote outside a string', () => {
+    expect(Helpers.quoteContextAt("fn.echo('a') + ", 13)).toBe(null);
+  });
+
+  it('reports the enclosing quote inside a string', () => {
+    expect(Helpers.quoteContextAt("fn.echo('abc')", 9)).toBe("'");
+  });
+
+  it('ignores the other quote character inside a string', () => {
+    // the apostrophe in "it's" does not open a string
+    expect(Helpers.quoteContextAt('fn.echo("it\'s ok", 1)', 18)).toBe(null);
+  });
+
+  it('ignores an escaped quote', () => {
+    expect(Helpers.quoteContextAt("fn.echo('it\\'s ok')", 15)).toBe("'");
+  });
+});

--- a/server/tests/replacement-patterns.test.mjs
+++ b/server/tests/replacement-patterns.test.mjs
@@ -61,16 +61,28 @@ describe("the client's placeholder substitution inserts values verbatim", () => 
     assert.ok(fn.includes("stringifyValue"), "should be the substitution branch");
   });
 
-  test("the expression branch uses a function replacement", () => {
-    assert.match(fn, /value\?\.replace\(new RegExp\([^)]*\),\s*\(\)\s*=>\s*literal\)/);
+  test("the expression branch delegates to the helper", () => {
+    // what it does with the value depends on where the placeholder sits (inside a string
+    // literal, wrapped in quotes, or bare) - client/tests/expression-placeholders.test.js
+    // covers that; here we only pin that this branch does not paste the value in itself
+    assert.match(fn, /value\s*=\s*Helpers\.substituteExpressionPlaceholder\(/);
+    assert.doesNotMatch(fn.slice(0, fn.indexOf("} else {")), /\.replace\(/,
+      "the expression branch must not paste a value in through String.replace");
   });
 
   test("the plain branch uses a function replacement", () => {
     assert.match(fn, /value\?\.replace\(foundmatch,\s*\(\)\s*=>\s*fieldvalue\)/);
   });
 
-  test("the regex-escape above it still uses $& deliberately", () => {
-    // that one IS a replacement pattern and must not be "fixed" along with the others
-    assert.match(fn, /replace\(\/\[\.\*\+\?\^\$\{\}\(\)\|\[\\\]\\\\\]\/g, '\\\\\$&'\)/);
+  test("the helper splices by index rather than by replacement", () => {
+    // slice concatenation cannot re-interpret $& , $1 or $` in a value at all, which is
+    // why the regex the expression branch used to build is gone
+    const helpers = readFileSync(path.join(here, "../../client/src/lib/Helpers.js"), "utf8");
+    const start = helpers.indexOf("substituteExpressionPlaceholder(");
+    assert.ok(start > -1, "helper not found, so this assertion would be vacuous");
+    const body = helpers.slice(start, helpers.indexOf("quoteContextAt(expression, index)", start));
+    assert.match(body, /expression\.slice\(0, at\)\s*\+/);
+    assert.doesNotMatch(body, /expression\.replace\(/,
+      "a value must never be handed to String.replace as a string replacement");
   });
 });


### PR DESCRIPTION
Reported against the 6.3.0-rc build: an expression that reads a file under a constant path fails with `ENOENT`, and the log shows the path carrying quotes it never had.

```
info : Expression: fn.fnReadYamlFile('"/app/dist/persistent"/playbooks/vars/clusters.yml')
error: Error in fnReadYamlFile : ENOENT: no such file or directory
```

## Cause

`replacePlaceholderInString` in `AppForm.vue` substitutes an `expression` placeholder as a JS literal, and only strips the surrounding quotes when they sit immediately around the placeholder:

```js
const literal = isObjectLiteral ? fieldvalue : JSON.stringify(fieldvalue)
value = value?.replace(new RegExp(`'${escaped}'|"${escaped}"|${escaped}`), () => literal)
```

When the placeholder is embedded in a longer string, only the bare alternative matches, so `JSON.stringify` writes its own quotes into the middle of the string. Every path and url built that way breaks. The AWX examples in `docs/faq.md` are all of this shape (`'https://.../job_templates?organization=$(organization)'`).

Regression introduced in 6.3.0; 6.2.1 had no expression branch and spliced the bare value in. Only `expression` mode is affected, queries, labels and validation messages take the `raw` path.

| template | 6.2.1 | 6.3.0 | this PR |
|---|---|---|---|
| `fn.fnReadYamlFile('$(BASEDIR)/vars/x.yml')` | `'/app/persistent/vars/x.yml'` | `'"/app/persistent"/vars/x.yml'` | `'/app/persistent/vars/x.yml'` |
| `fn.fnReadYamlFile('$(BASEDIR)')` | `'/app/persistent'` | `"/app/persistent"` | `"/app/persistent"` |
| `fn.upper('hello $(name)')`, name `O'Brien` | breaks the string | `'hello "O'Brien"'` | `'hello O\'Brien'` |
| `$(count) + 1` | `5 + 1` | `5 + 1` | `5 + 1` |

## Fix

Substitution now depends on where the placeholder sits, in `Helpers.substituteExpressionPlaceholder`:

-   quotes that wrap it are replaced together with it by a JS literal, so a value carrying an apostrophe cannot break out of the string (what the 6.3.0 change was for, kept)
-   inside a longer string the value is escaped for that quote character and spliced in as text
-   outside any string it stays a JS literal, so `$(count) + 1` still adds instead of concatenating

Splicing by index rather than through `String.replace` also removes the `$&` / `` $` `` / `$1` replacement-pattern hazard entirely, instead of working around it with a function replacement.

## Tests

`client/tests/expression-placeholders.test.js` (32 tests) asserts what the substituted expression *evaluates to*, not how it reads. Reverting the helper to the 6.3.0 behaviour fails 14 of them, including the exact reported line.

`server/tests/replacement-patterns.test.mjs` follows the code: the expression branch must delegate rather than paste a value in itself, and the helper must splice by index.

Client 281 tests in 12 files and server 852 in 49 pass, `lint:check` is clean on both, and `npm run build` succeeds.
