### PR TITLE
docs: repair the formfield type tables

### DIFF
--- a/docs/formfields/index.md
+++ b/docs/formfields/index.md
@@ -40,7 +40,12 @@ Browse the formfield types using the navigation sidebar, or refer to the table b
 {% for type in formfile.choices %}
     <tr>
       <td><strong><a href="/formfields/{{ type.name }}.html">{{ type.name }}</a></strong></td>
-      <td>{{ type.description }}</td>
+      <!-- markdownify, not the raw value : a description carries markdown (`code`
+           spans) AND html-looking text. The `html` type documents that `<script>` is
+           stripped, and unfiltered that opened a real script element which swallowed
+           every row after it - the page stopped at `html`, hiding 10 of the 14 types.
+           Kramdown escapes it inside the code span. -->
+      <td>{{ type.description | markdownify }}</td>
     </tr>
 {% endfor %}
   </tbody>

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,11 +194,21 @@ Get up and running quickly with AnsibleForms:
     </tr>
   </thead>
   <tbody>
-{% assign formfile = site.data.help[1].help[2].help[1].items[1] %}
+<!-- Looked up BY NAME, like every other page does. The previous positional path
+     (help[1].help[2].help[1].items[1]) silently stopped resolving when help.yaml
+     grew, so this table rendered with an empty body : no error, no rows, and
+     nothing to notice unless you knew the field types belonged here. -->
+{% assign help = site.data.help %}
+{% assign formsyaml = help | where: "link", "forms" | first %}
+{% assign form_object = formsyaml.help | where: "name", "Form" | first %}
+{% assign formfield = form_object.help | where: "name", "Formfield" | first %}
+{% assign formfile = formfield.items | where: "name", "type" | first %}
 {% for type in formfile.choices %}
     <tr>
       <td><strong>{{ type.name }}</strong></td>
-      <td>{{ type.description }}</td>
+      <!-- markdownify : see docs/formfields/index.md - an unfiltered description
+           puts a live <script> tag in the cell and truncates the table -->
+      <td>{{ type.description | markdownify }}</td>
     </tr>
 {% endfor %}
   </tbody>


### PR DESCRIPTION
Reported by Mirko: the formfields page "stops in the middle of a table, missing the other formfields". It does, and the same list on the home page is worse.

## /formfields/

`docs/formfields/index.md` printed the description unfiltered:

```liquid
<td>{{ type.description }}</td>
```

The `html` type's description documents that `<script>` is stripped when the field is rendered. Unfiltered, that text reaches the page as a **real script element**, so the browser reads every following row as script source. The table ends after `html`, hiding 10 of the 14 types (file, number, password, checkbox, radio, enum, expression, table, list, yaml).

The rows are in the served html the whole time, which is why nothing looks wrong when you read the page source. The stray `</script>` turns up after `</table>`:

```html
<td>An HTML field. The html is sanitized before it is rendered : `<script>`, ...
   ... </tbody> </table></div> </script></td></tr></tbody></table></div>
```

## The home page

`docs/index.md` picked the same list positionally:

```liquid
{% assign formfile = site.data.help[1].help[2].help[1].items[1] %}
```

That path drifted as `help.yaml` grew. It now resolves to the `name` property, which has no `choices`, so the loop produces nothing and "Types of Form Fields" renders as an empty table body. No error, no rows, nothing to notice unless you knew what belonged there. Live today:

```html
<h2 id="types-of-form-fields">...</h2>
<table> <thead>...</thead> <tbody> </tbody> </table>
```

## Fix

Both tables now look the list up **by name**, the way `/formfields/` and every other data-driven page already does, and pipe the description through `markdownify`, which escapes the tag inside its code span. That is exactly why no other page has ever broken this way: they all pipe descriptions through `markdownify` already, these two were the only raw ones.

Verified against `help.yaml`: the old positional path resolves to `name` with no choices, the lookup chain resolves to `type` with its 14 choices.

## Note, not fixed here

About twenty pages interpolate a description into an attribute, `<span title="{{ c.description }}">`. A description containing a double quote would break out of that attribute. None currently does (the `html` one, which carries `target="_blank"`, is not rendered in any of those loops), so this is latent rather than broken. Worth an `| escape` sweep if it ever bites.

## Verified

Not by reasoning about kramdown: the same sentence already renders through `markdownify` on [/formfields/expression.html](https://ansibleforms.com/formfields/expression.html), where the `isHtml` property carries it. Live output today:

```html
<code class="language-yaml highlighter-rouge"><span class="s">&lt;script&gt;</span></code>
```

Escaped inside the code span, no script element, and everything after it on that page renders. That is the behaviour these two tables were missing.

`Docs / Build` passes, so the lookup chain compiles. Note the PR build deliberately skips the artifact upload (`if: github.event_name != 'pull_request'`), so the rendered html cannot be inspected from CI, which is why the check above is against the live site instead.
