### PR TITLE
fix: evict the cached repository record when git state is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   `GET /api/v2/repository/<name>` kept answering with the `head` from before a pull for up to an hour. The repositories model is cached and `findByName` reads that cache, while the git operations wrote `status`, `output` and `head` with their own SQL and evicted nothing — so the single record disagreed with `GET /api/v2/repository` and with the database. Anything polling it to learn whether a commit had landed waited on a value that could not change
 -   Wizard didn't load varsFiles
 -   `target="_blank"` was stripped from links in `html` and `expression` fields, so they opened in the current tab and the form was lost (#480). `rel="noopener noreferrer"` is now forced on any link that opens a new tab
 -   Startup failed with `Failed to create the path for the log files` when `LOG_PATH`'s parent folder did not exist — the folder is now created recursively

--- a/server/src/models/repository.model.js
+++ b/server/src/models/repository.model.js
@@ -13,6 +13,36 @@ import { friendlyPullError, configRepoFromPath } from "../lib/forms-git.js";
 class Repository extends CrudModel {
   static modelName = 'repositories';
 
+  // Every state write below (status, output, head) uses its own SQL rather than
+  // CrudModel.update, so nothing evicts the record CrudModel.findByName serves from
+  // the shared cache -- crud.config.js enables allowCache on this model, and the
+  // cache holds an entry for an hour.
+  //
+  // Left uncached-aware, GET /api/v2/repository/<name> keeps answering with the head
+  // from BEFORE a pull while GET /api/v2/repository, which never reads the cache,
+  // answers correctly. Anything polling the single record to learn whether a commit
+  // landed -- a CI job asking "is the instance on my commit yet?" -- therefore waits
+  // on a value that cannot change until the entry expires.
+  //
+  // delete() already had to evict by hand for the same reason; this keeps every other
+  // path honest, so a new raw write cannot reintroduce it.
+  static evictCache({ name, id } = {}) {
+    const cache = CrudModel.getCache(this.modelName);
+    if (!cache) return;
+    if (name === undefined && id === undefined) return cache.flushAll();
+    if (name !== undefined) cache.del(`name:${name}`);
+    if (id !== undefined) cache.del(`id:${id}`);
+  }
+
+  // Run a state write and evict what it invalidated. Pass the key the statement is
+  // scoped to; omit it when the statement can touch rows this caller cannot name,
+  // and the whole model cache is dropped instead.
+  static async writeState(sql, params = [], key) {
+    const res = await mysql.do(sql, params);
+    Repository.evictCache(key);
+    return res;
+  }
+
   // Override create to trigger clone after creation
   // opts carries { fromSeed:true } for the declarative config seed only
   static async create(data, opts = {}) {
@@ -27,7 +57,7 @@ class Repository extends CrudModel {
     Repository.clone(data.name).catch(async (e) => {
       logger.error(`Background clone of '${data.name}' failed : ${helpers.getError(e)}`)
       try {
-        await mysql.do("update AnsibleForms.`repositories` set output = ?, status = 'failed' where name = ?", [helpers.getError(e), data.name])
+        await Repository.writeState("update AnsibleForms.`repositories` set output = ?, status = 'failed' where name = ?", [helpers.getError(e), data.name], { name: data.name })
       } catch (e2) {
         logger.error(`...and the failure could not be recorded on the repository either : ${helpers.getError(e2)}`)
       }
@@ -60,7 +90,7 @@ class Repository extends CrudModel {
       // exists on disk. The repository then read as 'not cloned', every pull failed, and
       // seed.ensureRepositoryClones cloned it again, orphaning the moved tree for good.
       if (!opts.fromSeed) await CrudModel.assertNotManaged(this.modelName, repo.id);
-      const claim = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+      const claim = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
       if (!claim.affectedRows) {
         throw new Error(`Repository '${name}' not found or already running, try again later`)
       }
@@ -71,7 +101,7 @@ class Repository extends CrudModel {
         moved = Repo.rename(name, newName);
         const res = await super.update(this.modelName, data, repo.id, opts);
         // release the claim under the NEW name - the row carries it now
-        await mysql.do("update AnsibleForms.`repositories` set status = ? where name = ?", [repo.status ?? null, newName])
+        await Repository.writeState("update AnsibleForms.`repositories` set status = ? where name = ?", [repo.status ?? null, newName])
         return res;
       } catch (e) {
         // Put the tree back. The row keeps the old name from here on, so a tree left at
@@ -85,7 +115,7 @@ class Repository extends CrudModel {
             logger.error(`Repository '${name}' could not be renamed and its working tree could not be moved back : it is now at '${newName}' while the record still says '${name}'. Move it back by hand. (${helpers.getError(e2)})`)
           }
         }
-        await mysql.do("update AnsibleForms.`repositories` set status = ? where id = ?", [repo.status ?? null, repo.id])
+        await Repository.writeState("update AnsibleForms.`repositories` set status = ? where id = ?", [repo.status ?? null, repo.id])
         throw e;
       }
     }
@@ -113,7 +143,7 @@ class Repository extends CrudModel {
     // afterwards hits Repo.clone's "already exists, pulling instead" path, so the new
     // repository silently pulls from the OLD remote and reports success.
     // Claimed after assertNotManaged, so a refused delete never touches the status.
-    const claim = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+    const claim = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
     if (!claim.affectedRows) {
       throw new Error(`Repository '${name}' not found or already running, try again later`)
     }
@@ -123,19 +153,14 @@ class Repository extends CrudModel {
       await Repo.delete(name);
     } catch (e) {
       // release the claim, or a failed rm wedges the repo at 'running' for ever
-      await mysql.do("update AnsibleForms.`repositories` set output = ?, status = 'failed' where name = ?", [e.message, name])
+      await Repository.writeState("update AnsibleForms.`repositories` set output = ?, status = 'failed' where name = ?", [e.message, name], { name })
       throw e
     }
-    const res = await mysql.do("DELETE FROM AnsibleForms.`repositories` WHERE name = ?", [name]);
-    // This deletes with its own SQL, so it must evict what CrudModel.delete would have.
-    // findByName above populated `name:<name>` in the shared cache (TTL 1h), so without
-    // this GET /api/v2/repository/<name> kept answering 200 with a deleted repository.
-    const cache = CrudModel.getCache(this.modelName);
-    if (cache) {
-      cache.del(`name:${name}`);
-      if (repo?.id !== undefined) cache.del(`id:${repo.id}`);
-    }
-    return res;
+    // Deletes with its own SQL, so it must evict what CrudModel.delete would have:
+    // findByName above populated `name:<name>` in the shared cache, and without the
+    // eviction GET /api/v2/repository/<name> kept answering 200 with a deleted
+    // repository.
+    return await Repository.writeState("DELETE FROM AnsibleForms.`repositories` WHERE name = ?", [name], { name, id: repo?.id });
   }
 
   static async findById(id) {
@@ -167,7 +192,7 @@ class Repository extends CrudModel {
     logger.info(`Resetting repository ${name}`);
     // claim the repo BEFORE deleting the tree : a reset rm's the working tree,
     // which must not race a pull/sync running git on it (issue #414)
-    const claim = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+    const claim = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
     if (!claim.affectedRows) {
       throw new Error(`Repository '${name}' not found or already running, try again later`)
     }
@@ -176,7 +201,7 @@ class Repository extends CrudModel {
       await Repository.clone(name, true); // recreate it ; clone writes the final status
     } catch (e) {
       // release the claim so a delete failure doesn't wedge the repo at 'running'
-      await mysql.do("update AnsibleForms.`repositories` set output = ?, status = 'failed' where name = ?", [e.message, name])
+      await Repository.writeState("update AnsibleForms.`repositories` set output = ?, status = 'failed' where name = ?", [e.message, name], { name })
       throw e
     }
   }
@@ -449,7 +474,7 @@ class Repository extends CrudModel {
     if (!claimed) {
       // atomic check-and-set : a clone must not run git while a pull/sync/reset
       // is touching the same working tree
-      const claim = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+      const claim = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
       if (!claim.affectedRows) {
         throw new Error(`Repository '${name}' not found or already running, try again later`)
       }
@@ -468,7 +493,7 @@ class Repository extends CrudModel {
       status = "failed"
     }
     output = Repository.maskSecrets(output, repo) // never expose git credentials
-    await mysql.do("update AnsibleForms.`repositories` set output = ?,status = ? where name = ?", [output, status, name])
+    await Repository.writeState("update AnsibleForms.`repositories` set output = ?,status = ? where name = ?", [output, status, name], { name })
     if (status == "success") {
       // Repo.info runs `git rev-parse --short HEAD`, which exits 128 on a repository
       // whose remote is EMPTY - a case this model explicitly supports (see
@@ -478,7 +503,7 @@ class Repository extends CrudModel {
       // in the background.
       try {
         head = await Repo.info(name)
-        await mysql.do("update AnsibleForms.`repositories` set head = ? where name = ?", [head, name])
+        await Repository.writeState("update AnsibleForms.`repositories` set head = ? where name = ?", [head, name], { name })
       } catch (e) {
         logger.warning(`'${name}' succeeded but its HEAD could not be read (an empty repository has none) : ${helpers.getError(e)}`)
       }
@@ -489,7 +514,7 @@ class Repository extends CrudModel {
     var output, status, head
     // atomic check-and-set : a pull and a sync (or another pull) must not run
     // git on the same working tree at the same time (issue #414)
-    const claimed = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+    const claimed = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
     if (!claimed.affectedRows) {
       throw new Error(`Repository '${name}' not found or already running, try again later`)
     }
@@ -515,7 +540,7 @@ class Repository extends CrudModel {
     } else {
       output = Repository.maskSecrets(output, pullRepo) // never expose git credentials
     }
-    await mysql.do("update AnsibleForms.`repositories` set output = ?,status = ? where name = ?", [output, status, name])
+    await Repository.writeState("update AnsibleForms.`repositories` set output = ?,status = ? where name = ?", [output, status, name], { name })
     if (status == "success") {
       // Repo.info runs `git rev-parse --short HEAD`, which exits 128 on a repository
       // whose remote is EMPTY - a case this model explicitly supports (see
@@ -525,7 +550,7 @@ class Repository extends CrudModel {
       // in the background.
       try {
         head = await Repo.info(name)
-        await mysql.do("update AnsibleForms.`repositories` set head = ? where name = ?", [head, name])
+        await Repository.writeState("update AnsibleForms.`repositories` set head = ? where name = ?", [head, name], { name })
       } catch (e) {
         logger.warning(`'${name}' succeeded but its HEAD could not be read (an empty repository has none) : ${helpers.getError(e)}`)
       }
@@ -608,7 +633,7 @@ class Repository extends CrudModel {
   static async claimForWrite(name) {
     const rows = await mysql.do("SELECT status FROM AnsibleForms.`repositories` WHERE name = ?", [name])
     if (!rows.length) return undefined // not a tracked repo (e.g. the staging folder) : skip
-    const claim = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+    const claim = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
     if (!claim.affectedRows) {
       throw new Error(`Repository '${name}' is busy (a pull or sync is running), try again`)
     }
@@ -624,14 +649,14 @@ class Repository extends CrudModel {
   // guarded on status='running' so it only ever clears OUR own claim and never
   // overwrites a status another operation legitimately set afterwards
   static async releaseWrite(name, priorStatus) {
-    await mysql.do("update AnsibleForms.`repositories` set status = ? where name = ? and status = 'running'", [priorStatus ?? null, name])
+    await Repository.writeState("update AnsibleForms.`repositories` set status = ? where name = ? and status = 'running'", [priorStatus ?? null, name], { name })
   }
 
   // clear any repository left at status='running' by a process that died mid
   // pull/sync : the atomic claim (status<>'running') would otherwise wedge the
   // repo forever. Run once at startup, mirroring Job.abandon (issue #414)
   static async resetStaleLocks() {
-    const result = await mysql.do("update AnsibleForms.`repositories` set status = 'failed' where status = 'running'")
+    const result = await Repository.writeState("update AnsibleForms.`repositories` set status = 'failed' where status = 'running'", [])
     return result.affectedRows || 0
   }
 
@@ -691,7 +716,7 @@ class Repository extends CrudModel {
     var output, status, head, syncRepo = null
     // atomic check-and-set : refuse concurrent syncs of the same repository
     // (eg the settings page button while a designer push is in flight)
-    const claimed = await mysql.do("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name])
+    const claimed = await Repository.writeState("update AnsibleForms.`repositories` set status = 'running' where name = ? and COALESCE(status,'') <> 'running'", [name], { name })
     if (!claimed.affectedRows) {
       throw new Error(`Repository '${name}' not found or already running, try again later`)
     }
@@ -718,7 +743,7 @@ class Repository extends CrudModel {
       status = "failed"
     }
     output = Repository.maskSecrets(output, syncRepo) // never expose git credentials
-    await mysql.do("update AnsibleForms.`repositories` set output = ?,status = ? where name = ?", [output, status, name])
+    await Repository.writeState("update AnsibleForms.`repositories` set output = ?,status = ? where name = ?", [output, status, name], { name })
     if (status == "success") {
       // Repo.info runs `git rev-parse --short HEAD`, which exits 128 on a repository
       // whose remote is EMPTY - a case this model explicitly supports (see
@@ -728,7 +753,7 @@ class Repository extends CrudModel {
       // in the background.
       try {
         head = await Repo.info(name)
-        await mysql.do("update AnsibleForms.`repositories` set head = ? where name = ?", [head, name])
+        await Repository.writeState("update AnsibleForms.`repositories` set head = ? where name = ?", [head, name], { name })
       } catch (e) {
         logger.warning(`'${name}' succeeded but its HEAD could not be read (an empty repository has none) : ${helpers.getError(e)}`)
       }

--- a/server/tests/repository-cache-eviction.test.mjs
+++ b/server/tests/repository-cache-eviction.test.mjs
@@ -1,0 +1,90 @@
+// The repositories model is cached (crud.config.js sets allowCache, entries live an
+// hour) and CrudModel.findByName serves from that cache, while CrudModel.findAll never
+// touches it. Every git operation in the model writes status/output/head with its own
+// SQL rather than through CrudModel.update, so nothing evicted the cached record.
+//
+// The effect, measured against a live 6.2.1 instance: after a pull moved a repository
+// to a new commit, GET /api/v2/repository/<name> kept answering with the PREVIOUS head
+// while GET /api/v2/repository and the database both showed the new one. A CI job
+// polling the single record to learn whether its commit had landed waited on a value
+// that could not change until the entry expired, and reported a failed deploy over a
+// pull that had already succeeded.
+//
+// delete() already evicted by hand for the same reason. These pin it for the rest.
+import { test, describe, beforeEach, vi } from "vitest";
+import assert from "node:assert/strict";
+
+process.env.DB_HOST ||= "127.0.0.1";
+process.env.DB_PORT ||= "3306";
+process.env.DB_USER ||= "test";
+process.env.DB_PASSWORD ||= "test";
+
+const sql = [];
+vi.mock("../src/models/db.model.js", () => ({
+  default: { do: async (statement) => { sql.push(statement); return { affectedRows: 1 }; } },
+}));
+
+vi.mock("../src/models/repo.model.js", () => ({
+  default: {
+    pull: async () => "Already up to date.",
+    clone: async () => "Cloning into 'x'...",
+    delete: async () => {},
+    info: async () => "new1234",
+    maskGitToken: (s) => s,
+  },
+}));
+
+// A cache that records what was evicted, standing in for the shared NodeCache.
+const evicted = [];
+let flushed = 0;
+vi.mock("../src/models/crud.model.js", () => {
+  class CrudModel {
+    static getCache() {
+      return {
+        del: (key) => evicted.push(key),
+        flushAll: () => { flushed += 1; },
+        get: () => undefined,
+        set: () => {},
+      };
+    }
+    static async findByName(modelName, name) {
+      return { id: 7, name, uri: "https://example.invalid/x.git", use_for_forms: 0 };
+    }
+    static async findAll() { return []; }
+    static async assertNotManaged() {}
+    static async update() {}
+  }
+  return { default: CrudModel };
+});
+
+const { default: Repository } = await import("../src/models/repository.model.js");
+
+describe("the cached repository record is evicted when state is written", () => {
+  beforeEach(() => { sql.length = 0; evicted.length = 0; flushed = 0; });
+
+  test("a pull evicts the record it just moved", async () => {
+    await Repository.pull("myrepo");
+    assert.ok(sql.some((s) => s.includes("set head = ?")), "the head was never written");
+    assert.ok(
+      evicted.includes("name:myrepo"),
+      `the pull left name:myrepo cached, so findByName keeps the old head (evicted: ${evicted.join(", ") || "nothing"})`,
+    );
+  });
+
+  test("writeState evicts by name", async () => {
+    await Repository.writeState("update AnsibleForms.`repositories` set status = ? where name = ?", ["success", "myrepo"], { name: "myrepo" });
+    assert.deepEqual(evicted, ["name:myrepo"]);
+  });
+
+  test("writeState evicts by id as well when given one", async () => {
+    await Repository.writeState("update AnsibleForms.`repositories` set status = ? where id = ?", ["success", 7], { name: "myrepo", id: 7 });
+    assert.deepEqual(evicted, ["name:myrepo", "id:7"]);
+  });
+
+  test("a statement with no key drops the whole model cache", async () => {
+    // resetStaleLocks updates every running row; this caller cannot name them.
+    await Repository.writeState("update AnsibleForms.`repositories` set status = 'failed' where status = 'running'");
+    assert.equal(flushed, 1, "an unscoped write must not leave stale entries behind");
+    assert.deepEqual(evicted, []);
+  });
+});


### PR DESCRIPTION
The repositories model is cached — `crud.config.js` sets `allowCache: true`, and `CrudModel.getCache` gives it a `stdTTL` of 3600. `CrudModel.findByName` serves from that cache; `CrudModel.findAll` never touches it.

Every git operation in `repository.model.js` writes `status`, `output` and `head` with its own SQL rather than through `CrudModel.update`, so nothing evicted the cached record.

### What it looks like

After a pull moves a repository to a new commit, for up to an hour:

| | head |
|---|---|
| the `repositories` row in MySQL | `4f37194` (new) |
| `GET /api/v2/repository` (list) | `4f37194` (new) |
| `GET /api/v2/repository/<name>` (single) | `f0084fd` (**previous**) |

I hit this from a CI job that publishes forms by asking the instance to pull and then polling the single record until `head` matches the commit it pushed. The pull succeeded every time; the endpoint reported the old commit until the cache entry expired, so the job waited out its timeout and reported a failed deploy over a pull that had already worked. Reproduced on 6.2.1 both through the ingress and directly against the pod, with one replica and one database — and the same code path is unchanged on `develop`.

### The fix

`delete()` already evicted by hand for exactly this reason, with a comment describing the same trap (`GET /api/v2/repository/<name>` answering 200 for a deleted repository). This generalises that rather than repeating it.

Every state write now goes through `Repository.writeState(sql, params, key)`, which runs the statement and evicts what it invalidated:

- keyed by `{ name }` (and `{ id }` where known) for statements scoped to one repository;
- no key for statements that can touch rows the caller cannot name — `resetStaleLocks` updates every running row — where the model cache is dropped instead.

All 20 raw writes in the model now route through it, so a new one cannot reintroduce the bug by forgetting to evict. `delete()` now uses the same helper.

### Tests

`server/tests/repository-cache-eviction.test.mjs` pins that a pull evicts the record it just moved, that the key variants evict what they should, and that an unscoped write flushes. Verified they fail against the unfixed model — neutering `evictCache` turns all four red with `the pull left name:myrepo cached, so findByName keeps the old head`.

Full server suite: **869 passed / 51 files**. ESLint clean on both touched files.